### PR TITLE
geom_alt props

### DIFF
--- a/data/421/180/089/421180089.geojson
+++ b/data/421/180/089/421180089.geojson
@@ -227,6 +227,9 @@
     },
     "wof:country":"LR",
     "wof:created":1459009244,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"2d92fa8e2857d612e9a96ef165d03859",
     "wof:hierarchy":[
         {
@@ -238,7 +241,7 @@
         }
     ],
     "wof:id":421180089,
-    "wof:lastmodified":1566596275,
+    "wof:lastmodified":1582345769,
     "wof:name":"Bensonville",
     "wof:parent_id":1091694045,
     "wof:placetype":"locality",

--- a/data/421/195/425/421195425.geojson
+++ b/data/421/195/425/421195425.geojson
@@ -575,6 +575,9 @@
     },
     "wof:country":"LR",
     "wof:created":1459009848,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8744ef2b9ce27632ab4948c4c25924bd",
     "wof:hierarchy":[
         {
@@ -586,7 +589,7 @@
         }
     ],
     "wof:id":421195425,
-    "wof:lastmodified":1566596274,
+    "wof:lastmodified":1582345769,
     "wof:name":"Monrovia",
     "wof:parent_id":1091694121,
     "wof:placetype":"locality",

--- a/data/856/322/49/85632249.geojson
+++ b/data/856/322/49/85632249.geojson
@@ -864,6 +864,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -919,6 +920,11 @@
     },
     "wof:country":"LR",
     "wof:country_alpha3":"LBR",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"7e7a567c30e838bd0362588c415e778f",
     "wof:hierarchy":[
         {
@@ -933,7 +939,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595942,
+    "wof:lastmodified":1582345762,
     "wof:name":"Liberia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/322/49/85632249.geojson
+++ b/data/856/322/49/85632249.geojson
@@ -864,7 +864,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -939,7 +938,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1582345762,
+    "wof:lastmodified":1583224734,
     "wof:name":"Liberia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/735/03/85673503.geojson
+++ b/data/856/735/03/85673503.geojson
@@ -137,6 +137,9 @@
         "unlc:id":"LR-RG"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e979915f1b5712a99937555b8631836",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595944,
+    "wof:lastmodified":1582345764,
     "wof:name":"River Gee",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/07/85673507.geojson
+++ b/data/856/735/07/85673507.geojson
@@ -135,6 +135,9 @@
         "iso:id":"LR-GP"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d3ede82eec585acefda23982310cca1f",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595946,
+    "wof:lastmodified":1582345764,
     "wof:name":"Gbapolu",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/13/85673513.geojson
+++ b/data/856/735/13/85673513.geojson
@@ -275,6 +275,9 @@
         "wk:page":"Grand Kru County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"88cc441a48580945903a627cfe4011c7",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595947,
+    "wof:lastmodified":1582345764,
     "wof:name":"Grand Kru",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/17/85673517.geojson
+++ b/data/856/735/17/85673517.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Maryland County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"562ea2c60957225b14994342509123e1",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595945,
+    "wof:lastmodified":1582345764,
     "wof:name":"Maryland",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/19/85673519.geojson
+++ b/data/856/735/19/85673519.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Sinoe County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b01861481911e1152686daa4dd1d8ab2",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595946,
+    "wof:lastmodified":1582345764,
     "wof:name":"Sinoe",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/23/85673523.geojson
+++ b/data/856/735/23/85673523.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Bomi County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c8e60dab9bb2a64f46c060c153b8d26",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595946,
+    "wof:lastmodified":1582345764,
     "wof:name":"Bomi",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/25/85673525.geojson
+++ b/data/856/735/25/85673525.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Bong County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e01e9095a63f37102932d9306a042ce6",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595947,
+    "wof:lastmodified":1582345764,
     "wof:name":"Bong",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/31/85673531.geojson
+++ b/data/856/735/31/85673531.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Grand Bassa County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de4cd855dad4fae43ff068e48d2d23ee",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595946,
+    "wof:lastmodified":1582345764,
     "wof:name":"Grand Bassa",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/35/85673535.geojson
+++ b/data/856/735/35/85673535.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Grand Cape Mount County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"555c3c75942dd914bd348de58ca452ef",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595945,
+    "wof:lastmodified":1582345764,
     "wof:name":"Grand Cape Mount",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/39/85673539.geojson
+++ b/data/856/735/39/85673539.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Lofa County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"be12b72533addfef3f358dcc6e300006",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595946,
+    "wof:lastmodified":1582345764,
     "wof:name":"Lofa",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/41/85673541.geojson
+++ b/data/856/735/41/85673541.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Montserrado County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c3aed16b262df5cba8345363c886a71",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595946,
+    "wof:lastmodified":1582345764,
     "wof:name":"Montserrado",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/45/85673545.geojson
+++ b/data/856/735/45/85673545.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Margibi County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c009e81f1d0f9c969f1ad60b805d0b2",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595945,
+    "wof:lastmodified":1582345764,
     "wof:name":"Margibi",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/51/85673551.geojson
+++ b/data/856/735/51/85673551.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Nimba County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f0b109f210e37060846acb4b2d520f31",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595945,
+    "wof:lastmodified":1582345764,
     "wof:name":"Nimba",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/57/85673557.geojson
+++ b/data/856/735/57/85673557.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Rivercess County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efa38b90ead213d7e0b96c5f558e5ec8",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595944,
+    "wof:lastmodified":1582345763,
     "wof:name":"River Cess",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/59/85673559.geojson
+++ b/data/856/735/59/85673559.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Grand Gedeh County"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aab371a683803cfb37da42fa61f2c1df",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566595944,
+    "wof:lastmodified":1582345763,
     "wof:name":"Grand Gedeh",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/857/655/77/85765577.geojson
+++ b/data/857/655/77/85765577.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":279381
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb8a612f0eb4d2aa73b524e688f20cde",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566595941,
+    "wof:lastmodified":1582345762,
     "wof:name":"Bassa Community",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/79/85765579.geojson
+++ b/data/857/655/79/85765579.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":1168010
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"55238309bc8b90c8c0d552ef1d927493",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566595941,
+    "wof:lastmodified":1582345762,
     "wof:name":"Crown Hill",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/85/85765585.geojson
+++ b/data/857/655/85/85765585.geojson
@@ -75,6 +75,9 @@
         "qs:id":266860
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d178a355b0f06a811c39726ce08bc72",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379377,
+    "wof:lastmodified":1582345762,
     "wof:name":"Plonkor",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/89/85765589.geojson
+++ b/data/857/655/89/85765589.geojson
@@ -77,6 +77,9 @@
         "wk:page":"Sinkor"
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9355cc5da3b8c0b1f016f30ea3d7232c",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379377,
+    "wof:lastmodified":1582345762,
     "wof:name":"Sinkor",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/93/85765593.geojson
+++ b/data/857/655/93/85765593.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":279388
     },
     "wof:country":"LR",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ad42096a16ae5f700c6b2dee61f1207",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566595941,
+    "wof:lastmodified":1582345762,
     "wof:name":"Westpoint",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.