### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/109/169/234/5/1091692345.geojson
+++ b/data/109/169/234/5/1091692345.geojson
@@ -32,11 +32,13 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ceb_x_preferred":[
+        "Klay District"
+    ],
     "name:eng_x_preferred":[
         "Klay"
     ],
     "name:eng_x_variant":[
-        "Klay",
         "Klay District"
     ],
     "name:fra_x_preferred":[
@@ -59,6 +61,9 @@
     ],
     "name:swe_x_preferred":[
         "Klay District"
+    ],
+    "name:uzb_x_preferred":[
+        "Klay tumani"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -96,7 +101,7 @@
         }
     ],
     "wof:id":1091692345,
-    "wof:lastmodified":1566596244,
+    "wof:lastmodified":1690938587,
     "wof:name":"Klay",
     "wof:parent_id":85673523,
     "wof:placetype":"county",

--- a/data/109/169/244/5/1091692445.geojson
+++ b/data/109/169/244/5/1091692445.geojson
@@ -32,11 +32,19 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:bul_x_preferred":[
+        "\u041a\u043e\u043a\u043e\u044f\u0445"
+    ],
+    "name:ceb_x_preferred":[
+        "Kokoyah"
+    ],
+    "name:cym_x_preferred":[
+        "Kokoyah"
+    ],
     "name:eng_x_preferred":[
         "Kokoyah"
     ],
     "name:eng_x_variant":[
-        "Kokoyah",
         "Kokoyah District"
     ],
     "name:fra_x_preferred":[
@@ -50,6 +58,12 @@
     ],
     "name:por_x_preferred":[
         "Kokoyah"
+    ],
+    "name:swe_x_preferred":[
+        "Kokoyah"
+    ],
+    "name:uzb_x_preferred":[
+        "Kokoyah tumani"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -87,7 +101,7 @@
         }
     ],
     "wof:id":1091692445,
-    "wof:lastmodified":1566596243,
+    "wof:lastmodified":1690938587,
     "wof:name":"Kokoyah",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/248/3/1091692483.geojson
+++ b/data/109/169/248/3/1091692483.geojson
@@ -32,11 +32,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:bul_x_preferred":[
+        "\u0424\u0443\u0430\u043c\u0430\u0445"
+    ],
+    "name:ceb_x_preferred":[
+        "Fuamah"
+    ],
     "name:eng_x_preferred":[
         "Fuamah"
     ],
     "name:eng_x_variant":[
-        "Fuamah",
         "Fuamah District"
     ],
     "name:fra_x_preferred":[
@@ -49,6 +54,9 @@
         "Fuamah District"
     ],
     "name:por_x_preferred":[
+        "Fuamah"
+    ],
+    "name:swe_x_preferred":[
         "Fuamah"
     ],
     "src:geom":"meso",
@@ -87,7 +95,7 @@
         }
     ],
     "wof:id":1091692483,
-    "wof:lastmodified":1566596247,
+    "wof:lastmodified":1690938588,
     "wof:name":"Fuamah",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/252/5/1091692525.geojson
+++ b/data/109/169/252/5/1091692525.geojson
@@ -32,11 +32,13 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ceb_x_preferred":[
+        "Salala"
+    ],
     "name:eng_x_preferred":[
         "Salala"
     ],
     "name:eng_x_variant":[
-        "Salala",
         "Salala District"
     ],
     "name:fra_x_preferred":[
@@ -53,6 +55,9 @@
     ],
     "name:swe_x_preferred":[
         "Salala"
+    ],
+    "name:uzb_x_preferred":[
+        "Salala tumani"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -90,7 +95,7 @@
         }
     ],
     "wof:id":1091692525,
-    "wof:lastmodified":1566596249,
+    "wof:lastmodified":1690938588,
     "wof:name":"Salala",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/255/5/1091692555.geojson
+++ b/data/109/169/255/5/1091692555.geojson
@@ -56,6 +56,9 @@
     "name:swe_x_preferred":[
         "Zota"
     ],
+    "name:uzb_x_preferred":[
+        "Zota tumani"
+    ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":1091692555,
-    "wof:lastmodified":1566596248,
+    "wof:lastmodified":1690938588,
     "wof:name":"Zota",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/404/5/1091694045.geojson
+++ b/data/109/169/404/5/1091694045.geojson
@@ -53,6 +53,9 @@
     "name:nld_x_preferred":[
         "Careysburg District"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u044d\u0440\u0438\u0441\u0431\u0435\u0440\u0433"
+    ],
     "name:swe_x_preferred":[
         "Careysburg"
     ],
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":1091694045,
-    "wof:lastmodified":1566596248,
+    "wof:lastmodified":1690938588,
     "wof:name":"Careysburg",
     "wof:parent_id":85673541,
     "wof:placetype":"county",

--- a/data/112/609/407/5/1126094075.geojson
+++ b/data/112/609/407/5/1126094075.geojson
@@ -23,8 +23,14 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:azb_x_preferred":[
+        "\u0633\u06cc\u0646\u06a9\u0648\u0631"
+    ],
     "name:eng_x_preferred":[
         "Sinkor"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d9\u05e0\u05e7\u05d5\u05e8"
     ],
     "name:nld_x_preferred":[
         "Sinkor"
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":1126094075,
-    "wof:lastmodified":1566596277,
+    "wof:lastmodified":1690938593,
     "wof:name":"Sinkor",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/114/190/608/3/1141906083.geojson
+++ b/data/114/190/608/3/1141906083.geojson
@@ -21,6 +21,12 @@
     "name:ara_x_preferred":[
         "\u0646\u0647\u0631 \u0633\u064a\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u0647\u0631 \u0633\u064a\u0633"
+    ],
+    "name:ast_x_preferred":[
+        "River Cess"
+    ],
     "name:ben_x_preferred":[
         "\u09b0\u09bf\u09ad\u09be\u09b0\u09b8\u09c7\u09b8"
     ],
@@ -47,6 +53,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e8\u05d9\u05d1\u05e8\u05e1"
+    ],
+    "name:heb_x_variant":[
+        "\u05e8\u05d9\u05d1\u05e8 \u05e1\u05e1"
     ],
     "name:hin_x_preferred":[
         "\u0930\u093f\u0935\u0930\u0938\u0947\u0938"
@@ -101,6 +110,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0631\u06cc\u0648\u0631\u0633\u06cc\u0633"
+    ],
+    "name:uzb_x_preferred":[
+        "River Cess"
     ],
     "name:vie_x_preferred":[
         "Rivercess"
@@ -227,7 +239,7 @@
         }
     ],
     "wof:id":1141906083,
-    "wof:lastmodified":1636500666,
+    "wof:lastmodified":1690938595,
     "wof:name":"Rivercess",
     "wof:parent_id":1091694479,
     "wof:placetype":"locality",

--- a/data/421/168/953/421168953.geojson
+++ b/data/421/168/953/421168953.geojson
@@ -20,8 +20,17 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0643\u0627\u062a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0643\u0627\u062a\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Kakata"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0430\u043a\u0430\u0442\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u0430\u043a\u0430\u0442\u0430"
     ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u0995\u09be\u099f\u09be"
@@ -255,7 +264,7 @@
         }
     ],
     "wof:id":421168953,
-    "wof:lastmodified":1636500661,
+    "wof:lastmodified":1690938589,
     "wof:name":"Kakata",
     "wof:parent_id":1091693791,
     "wof:placetype":"locality",

--- a/data/421/168/955/421168955.geojson
+++ b/data/421/168/955/421168955.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u063a\u0628\u0627\u0631\u0646\u063a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0628\u0627\u0631\u0646\u062c\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u09b0\u0999\u09cd\u0997\u09be"
     ],
@@ -53,7 +56,13 @@
     "name:fas_x_preferred":[
         "\u062c\u06cc\u0628\u0627\u0631\u0646\u06af\u0627"
     ],
+    "name:fin_x_preferred":[
+        "Gbarnga"
+    ],
     "name:fra_x_preferred":[
+        "Gbarnga"
+    ],
+    "name:hau_x_preferred":[
         "Gbarnga"
     ],
     "name:heb_x_preferred":[
@@ -112,6 +121,9 @@
     ],
     "name:swe_x_preferred":[
         "Gbarnga"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e1a\u0e32\u0e23\u0e4c\u0e07\u0e32"
     ],
     "name:tur_x_preferred":[
         "Gbarnga"
@@ -271,7 +283,7 @@
         }
     ],
     "wof:id":421168955,
-    "wof:lastmodified":1636500661,
+    "wof:lastmodified":1690938589,
     "wof:name":"Gbarnga",
     "wof:parent_id":1091692697,
     "wof:placetype":"locality",

--- a/data/421/170/835/421170835.geojson
+++ b/data/421/170/835/421170835.geojson
@@ -17,8 +17,17 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u063a\u0627\u0646\u062a\u0627"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0413\u0430\u043d\u0442\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0413\u0430\u043d\u0442\u0430"
+    ],
+    "name:ceb_x_preferred":[
+        "Ganta"
     ],
     "name:deu_x_preferred":[
         "Ganta"
@@ -31,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "Ganta"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ac\u30f3\u30bf"
     ],
     "name:kat_x_preferred":[
         "\u10d2\u10d0\u10dc\u10e2\u10d0"
@@ -105,7 +117,7 @@
         }
     ],
     "wof:id":421170835,
-    "wof:lastmodified":1566596275,
+    "wof:lastmodified":1690938591,
     "wof:name":"Ganta",
     "wof:parent_id":1091694197,
     "wof:placetype":"locality",

--- a/data/421/174/663/421174663.geojson
+++ b/data/421/174/663/421174663.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0647\u0627\u0631\u0628\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0647\u0627\u0631\u0628\u0631"
+    ],
     "name:ben_x_preferred":[
         "\u09b9\u09be\u09b0\u09cd\u09aa\u09be\u09b0"
     ],
@@ -44,7 +47,13 @@
     "name:fas_x_preferred":[
         "\u0647\u0627\u0631\u067e\u0631"
     ],
+    "name:fin_x_preferred":[
+        "Harper"
+    ],
     "name:fra_x_preferred":[
+        "Harper"
+    ],
+    "name:gle_x_preferred":[
         "Harper"
     ],
     "name:heb_x_preferred":[
@@ -103,6 +112,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0425\u0430\u0440\u043f\u0435\u0440"
+    ],
+    "name:ukr_x_variant":[
+        "\u0413\u0430\u0440\u043f\u0435\u0440"
     ],
     "name:und_x_variant":[
         "Cape Palmas"
@@ -259,7 +271,7 @@
         }
     ],
     "wof:id":421174663,
-    "wof:lastmodified":1636500661,
+    "wof:lastmodified":1690938590,
     "wof:name":"Harper",
     "wof:parent_id":1091693975,
     "wof:placetype":"locality",

--- a/data/421/178/825/421178825.geojson
+++ b/data/421/178/825/421178825.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0641\u0648\u0627\u0646\u062c\u0627\u0645\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0648\u0627\u0646\u062c\u0627\u0645\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u09ad\u09df\u09c7\u099e\u09cd\u099c\u09be\u09ae\u09be"
     ],
@@ -253,7 +256,7 @@
         }
     ],
     "wof:id":421178825,
-    "wof:lastmodified":1636500662,
+    "wof:lastmodified":1690938592,
     "wof:name":"Voinjama",
     "wof:parent_id":1091693427,
     "wof:placetype":"locality",

--- a/data/421/178/827/421178827.geojson
+++ b/data/421/178/827/421178827.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0643\u0627\u0646\u0627\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Buchanan"
+    ],
+    "name:azb_x_preferred":[
+        "\u0628\u0648\u0686\u0627\u0646\u0627\u0646"
+    ],
     "name:aze_x_preferred":[
         "Byukenen"
     ],
@@ -33,6 +39,9 @@
         "Buchanan"
     ],
     "name:ceb_x_preferred":[
+        "Buchanan"
+    ],
+    "name:ces_x_preferred":[
         "Buchanan"
     ],
     "name:dan_x_preferred":[
@@ -94,6 +103,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0411\u044c\u044e\u043a\u0435\u043d\u0435\u043d"
+    ],
+    "name:slk_x_preferred":[
+        "Buchanan"
     ],
     "name:spa_x_preferred":[
         "Buchanan"
@@ -264,7 +276,7 @@
         }
     ],
     "wof:id":421178827,
-    "wof:lastmodified":1636500662,
+    "wof:lastmodified":1690938592,
     "wof:name":"Buchanan",
     "wof:parent_id":1091692815,
     "wof:placetype":"locality",

--- a/data/421/180/089/421180089.geojson
+++ b/data/421/180/089/421180089.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u0646\u0633\u0648\u0646\u0641\u064a\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u064a\u0646\u0633\u0648\u0646\u0641\u064a\u0644\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Bensonville"
+    ],
     "name:bel_x_preferred":[
         "\u0411\u0435\u043d\u0441\u0430\u043d\u0432\u0456\u043b\u044c"
     ],
@@ -82,6 +88,9 @@
     ],
     "name:nob_x_preferred":[
         "Bensonville"
+    ],
+    "name:nqo_x_preferred":[
+        "\u07d3\u07cd\u07f2\u07db\u07d0\u07f2\u07dd\u07ed\u07cc\u07df"
     ],
     "name:pol_x_preferred":[
         "Bensonville"
@@ -265,7 +274,7 @@
         }
     ],
     "wof:id":421180089,
-    "wof:lastmodified":1636500661,
+    "wof:lastmodified":1690938590,
     "wof:name":"Bensonville",
     "wof:parent_id":1091694045,
     "wof:placetype":"locality",

--- a/data/421/183/487/421183487.geojson
+++ b/data/421/183/487/421183487.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0631\u0643\u0644\u0627\u064a\u0641\u064a\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0631\u0643\u0644\u0627\u064a\u0641\u064a\u0644\u0649"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u09b0\u09cd\u0995\u09b2\u09c7\u09ad\u09bf\u09b2\u09c7"
     ],
@@ -247,7 +250,7 @@
         }
     ],
     "wof:id":421183487,
-    "wof:lastmodified":1636500662,
+    "wof:lastmodified":1690938591,
     "wof:name":"Barclayville",
     "wof:parent_id":1091693271,
     "wof:placetype":"locality",

--- a/data/421/191/545/421191545.geojson
+++ b/data/421/191/545/421191545.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u064a\u0643\u064a\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646\u064a\u0643\u064a\u0644\u0649"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09cd\u09af\u09be\u09a8\u09bf\u0995\u09cd\u09af\u09c1\u09df\u09c7\u09b2\u09bf"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0633\u0627\u0646\u06cc\u06a9\u0648\u0626\u0644"
+    ],
+    "name:fin_x_preferred":[
+        "Sanniquellie"
     ],
     "name:fra_x_preferred":[
         "Sanniquellie"
@@ -58,6 +64,9 @@
     ],
     "name:ita_x_preferred":[
         "Sanniquelle"
+    ],
+    "name:ita_x_variant":[
+        "Sanniquellie"
     ],
     "name:jpn_x_preferred":[
         "\u30b5\u30cb\u30b1\u30ea\u30a8"
@@ -250,7 +259,7 @@
         }
     ],
     "wof:id":421191545,
-    "wof:lastmodified":1636500662,
+    "wof:lastmodified":1690938591,
     "wof:name":"Sanniquellie",
     "wof:parent_id":1091694197,
     "wof:placetype":"locality",

--- a/data/421/195/425/421195425.geojson
+++ b/data/421/195/425/421195425.geojson
@@ -28,10 +28,19 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0646\u0631\u0648\u0641\u064a\u0627"
     ],
+    "name:arg_x_preferred":[
+        "Monrovia"
+    ],
+    "name:ary_x_preferred":[
+        "\u0645\u0648\u0646\u0631\u0648\u06a4\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0645\u0648\u0646\u0631\u0648\u0641\u064a\u0627"
     ],
     "name:ast_x_preferred":[
+        "Monrovia"
+    ],
+    "name:avk_x_preferred":[
         "Monrovia"
     ],
     "name:azb_x_preferred":[
@@ -42,6 +51,9 @@
     ],
     "name:bam_x_preferred":[
         "M\u0254nrovia"
+    ],
+    "name:ban_x_preferred":[
+        "Monrovia"
     ],
     "name:bcl_x_preferred":[
         "Monrovia"
@@ -247,6 +259,12 @@
     "name:lav_x_preferred":[
         "Monrovija"
     ],
+    "name:lfn_x_preferred":[
+        "Monrovia"
+    ],
+    "name:lij_x_preferred":[
+        "Monr\u00f2vvia"
+    ],
     "name:lit_x_preferred":[
         "Monrovija"
     ],
@@ -262,6 +280,9 @@
     "name:mar_x_preferred":[
         "\u092e\u094b\u0928\u094d\u0930\u094b\u0935\u094d\u0939\u093f\u092f\u093e"
     ],
+    "name:mdf_x_preferred":[
+        "\u041c\u043e\u043d\u0440\u043e\u0432\u0438\u044f"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u043e\u043d\u0440\u043e\u0432\u0438\u0458\u0430"
     ],
@@ -273,6 +294,9 @@
     ],
     "name:msa_x_preferred":[
         "Monrovia"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0645\u0648\u0646\u0631\u0648\u0648\u06cc\u0627"
     ],
     "name:nah_x_preferred":[
         "Monrovia"
@@ -301,6 +325,12 @@
     "name:oci_x_preferred":[
         "Monr\u00f2via"
     ],
+    "name:olo_x_preferred":[
+        "Monrouvii"
+    ],
+    "name:oss_x_preferred":[
+        "\u041c\u043e\u043d\u0440\u043e\u0432\u0438"
+    ],
     "name:pan_x_preferred":[
         "\u0a2e\u0a4b\u0a28\u0a30\u0a4b\u0a35\u0a40\u0a06"
     ],
@@ -324,6 +354,9 @@
     ],
     "name:pus_x_preferred":[
         "\u0645\u0648\u0646\u0631\u0648\u0648\u06cc\u0627"
+    ],
+    "name:que_x_preferred":[
+        "Munruwya"
     ],
     "name:ron_x_preferred":[
         "Monrovia"
@@ -349,6 +382,15 @@
     "name:slv_x_preferred":[
         "Monrovija"
     ],
+    "name:sme_x_preferred":[
+        "Monrovia"
+    ],
+    "name:smn_x_preferred":[
+        "Monrovia"
+    ],
+    "name:sms_x_preferred":[
+        "Monrovia"
+    ],
     "name:sna_x_preferred":[
         "Monrovia"
     ],
@@ -371,6 +413,9 @@
         "Monrovia"
     ],
     "name:swe_x_preferred":[
+        "Monrovia"
+    ],
+    "name:szl_x_preferred":[
         "Monrovia"
     ],
     "name:tam_x_preferred":[
@@ -584,8 +629,8 @@
     "wof:belongsto":[
         102191573,
         85632249,
-        1091694121,
-        85673541
+        85673541,
+        1091694121
     ],
     "wof:breaches":[],
     "wof:capital_of":[
@@ -616,7 +661,7 @@
         }
     ],
     "wof:id":421195425,
-    "wof:lastmodified":1608688184,
+    "wof:lastmodified":1690938590,
     "wof:megacity":1,
     "wof:name":"Monrovia",
     "wof:parent_id":1091694121,

--- a/data/421/195/903/421195903.geojson
+++ b/data/421/195/903/421195903.geojson
@@ -77,6 +77,9 @@
     "name:pol_x_preferred":[
         "Greenville"
     ],
+    "name:por_x_preferred":[
+        "Greenville"
+    ],
     "name:rus_x_preferred":[
         "\u0413\u0440\u0438\u043d\u0432\u0438\u043b\u043b"
     ],
@@ -91,6 +94,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0413\u0440\u0456\u043d\u0432\u0456\u043b\u043b"
+    ],
+    "name:ukr_x_variant":[
+        "\u0413\u0440\u0438\u043d\u0432\u0456\u043b\u043b"
     ],
     "name:und_x_variant":[
         "Sinoe"
@@ -247,7 +253,7 @@
         }
     ],
     "wof:id":421195903,
-    "wof:lastmodified":1636500661,
+    "wof:lastmodified":1690938590,
     "wof:name":"Greenville",
     "wof:parent_id":1091694745,
     "wof:placetype":"locality",

--- a/data/421/198/527/421198527.geojson
+++ b/data/421/198/527/421198527.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0632\u0648\u064a\u062f\u0631\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0632\u0648\u064a\u062f\u0631\u0648"
+    ],
     "name:ben_x_preferred":[
         "\u0993\u09df\u09c7\u09a6\u09cd\u09b0\u09c1"
     ],
@@ -253,7 +256,7 @@
         }
     ],
     "wof:id":421198527,
-    "wof:lastmodified":1636500661,
+    "wof:lastmodified":1690938591,
     "wof:name":"Zwedru",
     "wof:parent_id":1091693117,
     "wof:placetype":"locality",

--- a/data/421/203/849/421203849.geojson
+++ b/data/421/203/849/421203849.geojson
@@ -17,6 +17,18 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0647\u0627\u0631\u0628\u064a\u0644"
+    ],
+    "name:ast_x_preferred":[
+        "Harbel"
+    ],
+    "name:bul_x_preferred":[
+        "\u0425\u0430\u0440\u0431\u0435\u043b"
+    ],
+    "name:ceb_x_preferred":[
+        "Harbel"
+    ],
     "name:deu_x_preferred":[
         "Harbel"
     ],
@@ -24,6 +36,9 @@
         "Harbel"
     ],
     "name:fra_x_preferred":[
+        "Harbel"
+    ],
+    "name:hau_x_preferred":[
         "Harbel"
     ],
     "name:ita_x_preferred":[
@@ -43,6 +58,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0425\u0430\u0440\u0431\u0435\u043b"
+    ],
+    "name:swe_x_preferred":[
+        "Harbel"
     ],
     "name:urd_x_preferred":[
         "\u06c1\u0627\u0631\u0628\u0644"
@@ -97,7 +115,7 @@
         }
     ],
     "wof:id":421203849,
-    "wof:lastmodified":1566596274,
+    "wof:lastmodified":1690938590,
     "wof:name":"Harbel",
     "wof:parent_id":1091693839,
     "wof:placetype":"locality",

--- a/data/856/322/49/85632249.geojson
+++ b/data/856/322/49/85632249.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u041b\u0438\u0431\u0435\u0440\u0438\u0430"
+    ],
     "name:ace_x_preferred":[
         "Liberia"
     ],
@@ -40,14 +43,23 @@
     "name:aka_x_preferred":[
         "Laeberia"
     ],
+    "name:aka_x_variant":[
+        "Liberia"
+    ],
     "name:als_x_preferred":[
         "Liberia"
     ],
     "name:amh_x_preferred":[
         "\u120b\u12ed\u1264\u122a\u12eb"
     ],
+    "name:ami_x_preferred":[
+        "Liberia"
+    ],
     "name:ang_x_preferred":[
         "Liberia"
+    ],
+    "name:anp_x_preferred":[
+        "\u0932\u093e\u0907\u092c\u0947\u0930\u093f\u092f\u093e"
     ],
     "name:ara_x_preferred":[
         "\u0644\u064a\u0628\u064a\u0631\u064a\u0627"
@@ -62,6 +74,9 @@
         "\u0644\u064a\u0628\u064a\u0631\u064a\u0627"
     ],
     "name:ast_x_preferred":[
+        "Liberia"
+    ],
+    "name:avk_x_preferred":[
         "Liberia"
     ],
     "name:azb_x_preferred":[
@@ -103,6 +118,9 @@
     ],
     "name:bho_x_preferred":[
         "\u0932\u093e\u0907\u092c\u0947\u0930\u093f\u092f\u093e"
+    ],
+    "name:bis_x_preferred":[
+        "Liberia"
     ],
     "name:bjn_x_preferred":[
         "Liberia"
@@ -158,6 +176,9 @@
     "name:cor_x_preferred":[
         "Liberi"
     ],
+    "name:cos_x_preferred":[
+        "Liberia"
+    ],
     "name:crh_x_preferred":[
         "Liberiya"
     ],
@@ -165,6 +186,9 @@
         "Liberi\u00f4"
     ],
     "name:cym_x_preferred":[
+        "Liberia"
+    ],
+    "name:dag_x_preferred":[
         "Liberia"
     ],
     "name:dan_x_preferred":[
@@ -275,6 +299,9 @@
     "name:glv_x_preferred":[
         "Yn Laibeer"
     ],
+    "name:gpe_x_preferred":[
+        "Liberia"
+    ],
     "name:grn_x_preferred":[
         "Liv\u00e9ria"
     ],
@@ -283,6 +310,12 @@
     ],
     "name:guj_x_preferred":[
         "\u0ab2\u0abe\u0a87\u0aac\u0ac7\u0ab0\u0abf\u0aaf\u0abe"
+    ],
+    "name:gur_x_preferred":[
+        "Liberia"
+    ],
+    "name:guw_x_preferred":[
+        "Liberia"
     ],
     "name:hak_x_preferred":[
         "Liberia"
@@ -346,6 +379,9 @@
     ],
     "name:jav_x_preferred":[
         "Liberia"
+    ],
+    "name:jav_x_variant":[
+        "Lib\u00e8ria"
     ],
     "name:jpn_x_preferred":[
         "\u30ea\u30d9\u30ea\u30a2"
@@ -434,6 +470,9 @@
     "name:lit_x_preferred":[
         "Liberija"
     ],
+    "name:lld_x_preferred":[
+        "Liberia"
+    ],
     "name:lmo_x_preferred":[
         "Liberia"
     ],
@@ -458,6 +497,12 @@
     "name:mar_x_preferred":[
         "\u0932\u093e\u092f\u092c\u0947\u0930\u093f\u092f\u093e"
     ],
+    "name:mdf_x_preferred":[
+        "\u041b\u0438\u0431\u044d\u0440\u0438\u044f"
+    ],
+    "name:mhr_x_preferred":[
+        "\u041b\u0438\u0431\u0435\u0440\u0438\u0439"
+    ],
     "name:min_x_preferred":[
         "Liberia"
     ],
@@ -472,6 +517,9 @@
     ],
     "name:mlt_x_preferred":[
         "Liberja"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc2\uabe4\uabd5\uabe6\uabd4\uabe4\uabcc\uabe5"
     ],
     "name:mon_x_preferred":[
         "\u041b\u0438\u0431\u0435\u0440\u0438"
@@ -511,6 +559,9 @@
     ],
     "name:nep_x_preferred":[
         "\u0932\u093e\u0907\u092c\u0947\u0930\u093f\u092f\u093e"
+    ],
+    "name:nep_x_variant":[
+        "\u0932\u093e\u0908\u092c\u0947\u0930\u093f\u092f\u093e"
     ],
     "name:new_x_preferred":[
         "\u0932\u093e\u0907\u092c\u0947\u0930\u093f\u092f\u093e"
@@ -629,6 +680,9 @@
     "name:sgs_x_preferred":[
         "Liber\u0117j\u0117"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101c\u1062\u1086\u1087\u1015\u1031\u1038\u101b\u102e\u1038\u101a\u1083\u1038"
+    ],
     "name:sin_x_preferred":[
         "\u0dbd\u0dba\u0dd2\u0db6\u0dd3\u0dbb\u0dd2\u0dba\u0dcf\u0dc0"
     ],
@@ -716,6 +770,9 @@
     "name:tat_x_preferred":[
         "\u041b\u0438\u0431\u0435\u0440\u0438\u044f"
     ],
+    "name:tay_x_preferred":[
+        "Liberia"
+    ],
     "name:tel_x_preferred":[
         "\u0c32\u0c48\u0c2c\u0c40\u0c30\u0c3f\u0c2f\u0c3e"
     ],
@@ -734,14 +791,23 @@
     "name:tir_x_preferred":[
         "\u120b\u12ed\u1264\u122a\u12eb"
     ],
+    "name:tok_x_preferred":[
+        "ma Lapewija"
+    ],
     "name:ton_x_preferred":[
         "Laipelia"
+    ],
+    "name:trv_x_preferred":[
+        "Liberia"
     ],
     "name:tso_x_preferred":[
         "Layiberiya"
     ],
     "name:tuk_x_preferred":[
         "Liberi\u00fda"
+    ],
+    "name:tum_x_preferred":[
+        "Liberia"
     ],
     "name:tur_x_preferred":[
         "Liberya"
@@ -1067,7 +1133,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1617827488,
+    "wof:lastmodified":1690938581,
     "wof:name":"Liberia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/735/13/85673513.geojson
+++ b/data/856/735/13/85673513.geojson
@@ -50,6 +50,9 @@
     "name:ceb_x_preferred":[
         "Grand Kru County"
     ],
+    "name:cym_x_preferred":[
+        "Sir Grand Kru"
+    ],
     "name:dan_x_preferred":[
         "Grand Kru County"
     ],
@@ -154,6 +157,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0bbf\u0bb0\u0bbe\u0ba3\u0bcd\u0b9f\u0bcd \u0b95\u0bcd\u0bb0\u0bc2 \u0b95\u0bb5\u0bc1\u0ba3\u0bcd\u0b9f\u0bbf"
+    ],
+    "name:tam_x_variant":[
+        "\u0b95\u0bbf\u0bb0\u0bbe\u0ba3\u0bcd\u0b9f\u0bcd  \u0b95\u0bcd\u0bb0\u0bc2 \u0b95\u0bb5\u0bc1\u0ba3\u0bcd\u0b9f\u0bbf"
     ],
     "name:tel_x_preferred":[
         "\u0c17\u0c4d\u0c30\u0c3e\u0c02\u0c21\u0c4d \u0c15\u0c4d\u0c30\u0c42 \u0c15\u0c4c\u0c02\u0c1f\u0c40"
@@ -299,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500653,
+    "wof:lastmodified":1690938585,
     "wof:name":"Grand Kru",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/17/85673517.geojson
+++ b/data/856/735/17/85673517.geojson
@@ -49,6 +49,9 @@
     "name:ceb_x_preferred":[
         "Maryland County"
     ],
+    "name:cym_x_preferred":[
+        "Sir Maryland"
+    ],
     "name:dan_x_preferred":[
         "Maryland"
     ],
@@ -171,6 +174,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0645\u06cc\u0631\u06cc \u0644\u06cc\u0646\u0688 \u06a9\u0627\u0624\u0646\u0679\u06cc\u060c \u0644\u0627\u0626\u0628\u06cc\u0631\u06cc\u0627"
+    ],
+    "name:uzb_x_preferred":[
+        "Maryland okrugi"
     ],
     "name:vie_x_preferred":[
         "H\u1ea1t Maryland"
@@ -301,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500652,
+    "wof:lastmodified":1690938583,
     "wof:name":"Maryland",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/19/85673519.geojson
+++ b/data/856/735/19/85673519.geojson
@@ -50,6 +50,9 @@
     "name:ceb_x_preferred":[
         "Sinoe County"
     ],
+    "name:cym_x_preferred":[
+        "Sir Sinoe"
+    ],
     "name:dan_x_preferred":[
         "Sinoe County"
     ],
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500652,
+    "wof:lastmodified":1690938584,
     "wof:name":"Sinoe",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/23/85673523.geojson
+++ b/data/856/735/23/85673523.geojson
@@ -50,6 +50,9 @@
     "name:ceb_x_preferred":[
         "Bomi County"
     ],
+    "name:cym_x_preferred":[
+        "Sir Bomi"
+    ],
     "name:dan_x_preferred":[
         "Bomi"
     ],
@@ -182,11 +185,17 @@
     "name:urd_x_preferred":[
         "\u0628\u0648\u0645\u06cc \u06a9\u0627\u0624\u0646\u0679\u06cc"
     ],
+    "name:uzb_x_preferred":[
+        "Bomi okrugi"
+    ],
     "name:vie_x_preferred":[
         "H\u1ea1t Bomi"
     ],
     "name:zho_x_preferred":[
         "\u4f2f\u7c73\u53bf"
+    ],
+    "name:zho_x_variant":[
+        "\u535a\u7c73\u53bf"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LBR",
@@ -311,7 +320,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500653,
+    "wof:lastmodified":1690938585,
     "wof:name":"Bomi",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/25/85673525.geojson
+++ b/data/856/735/25/85673525.geojson
@@ -50,6 +50,9 @@
     "name:ceb_x_preferred":[
         "Bong County"
     ],
+    "name:cym_x_preferred":[
+        "Sir Bong"
+    ],
     "name:dan_x_preferred":[
         "Bong County"
     ],
@@ -175,6 +178,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0628\u0648\u0646\u06af \u06a9\u0627\u0624\u0646\u0679\u06cc"
+    ],
+    "name:uzb_x_preferred":[
+        "Bong okrugi"
     ],
     "name:vie_x_preferred":[
         "H\u1ea1t Bong"
@@ -306,7 +312,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500653,
+    "wof:lastmodified":1690938585,
     "wof:name":"Bong",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/39/85673539.geojson
+++ b/data/856/735/39/85673539.geojson
@@ -50,6 +50,9 @@
     "name:ceb_x_preferred":[
         "Lofa County"
     ],
+    "name:cym_x_preferred":[
+        "Sir Lofa"
+    ],
     "name:dan_x_preferred":[
         "Lofa County"
     ],
@@ -172,6 +175,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0644\u0648\u0641\u0627 \u06a9\u0627\u0624\u0646\u0679\u06cc"
+    ],
+    "name:uzb_x_preferred":[
+        "Lofa okrugi"
     ],
     "name:vie_x_preferred":[
         "H\u1ea1t Lofa"
@@ -300,7 +306,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500653,
+    "wof:lastmodified":1690938584,
     "wof:name":"Lofa",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/41/85673541.geojson
+++ b/data/856/735/41/85673541.geojson
@@ -53,6 +53,9 @@
     "name:ceb_x_preferred":[
         "Montserrado County"
     ],
+    "name:cym_x_preferred":[
+        "Sir Montserrado"
+    ],
     "name:dan_x_preferred":[
         "Montserrado County"
     ],
@@ -152,6 +155,9 @@
     ],
     "name:sin_x_preferred":[
         "\u0db8\u0ddc\u0db1\u0dca\u0da7\u0dca\u0dc3\u0dd9\u0dbb\u0dcf\u0da9\u0ddd \u0db4\u0dca\u200d\u0dbb\u0dcf\u0db1\u0dca\u0dad\u0dba"
+    ],
+    "name:som_x_preferred":[
+        "Montserrado County"
     ],
     "name:spa_x_preferred":[
         "Condado de Montserrado"
@@ -310,7 +316,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500653,
+    "wof:lastmodified":1690938584,
     "wof:name":"Montserrado",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/45/85673545.geojson
+++ b/data/856/735/45/85673545.geojson
@@ -50,6 +50,9 @@
     "name:ceb_x_preferred":[
         "Margibi County"
     ],
+    "name:cym_x_preferred":[
+        "Sir Margibi"
+    ],
     "name:dan_x_preferred":[
         "Margibi County"
     ],
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500652,
+    "wof:lastmodified":1690938583,
     "wof:name":"Margibi",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/51/85673551.geojson
+++ b/data/856/735/51/85673551.geojson
@@ -171,6 +171,9 @@
     "name:urd_x_preferred":[
         "\u0646\u0645\u0628\u0627 \u06a9\u0627\u0624\u0646\u0679\u06cc"
     ],
+    "name:uzb_x_preferred":[
+        "Nimba okrugi"
+    ],
     "name:vie_x_preferred":[
         "Nimba"
     ],
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500651,
+    "wof:lastmodified":1690938583,
     "wof:name":"Nimba",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/59/85673559.geojson
+++ b/data/856/735/59/85673559.geojson
@@ -179,6 +179,9 @@
     "name:zho_x_preferred":[
         "\u5927\u5404\u5fb7\u53bf"
     ],
+    "name:zho_x_variant":[
+        "\u5927\u5409\u5fb7\u53bf"
+    ],
     "ne:abbrev":"",
     "ne:adm0_a3":"LBR",
     "ne:adm0_label":"2",
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500651,
+    "wof:lastmodified":1690938582,
     "wof:name":"Grand Gedeh",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/890/413/141/890413141.geojson
+++ b/data/890/413/141/890413141.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u062a\u0648\u0628\u0645\u0627\u0646\u0628\u0648\u0631\u063a"
+    ],
     "name:bre_x_preferred":[
         "Tubmanburg"
     ],
@@ -49,6 +52,9 @@
     "name:hye_x_preferred":[
         "\u0539\u0578\u0582\u0562\u0574\u0561\u0576\u0562\u0578\u0582\u0580\u0563"
     ],
+    "name:ind_x_preferred":[
+        "Tubmanburg"
+    ],
     "name:ita_x_preferred":[
         "Tubmanburg"
     ],
@@ -75,6 +81,9 @@
     ],
     "name:swe_x_preferred":[
         "Tubmanburg"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e17\u0e31\u0e1a\u0e41\u0e21\u0e19\u0e40\u0e1a\u0e34\u0e23\u0e4c\u0e01"
     ],
     "name:und_x_variant":[
         "Bomi Hills"
@@ -118,7 +127,7 @@
         }
     ],
     "wof:id":890413141,
-    "wof:lastmodified":1566596276,
+    "wof:lastmodified":1690938592,
     "wof:name":"Tubmanburg",
     "wof:parent_id":1091692345,
     "wof:placetype":"locality",

--- a/data/890/417/993/890417993.geojson
+++ b/data/890/417/993/890417993.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0628\u0648\u0644\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0628\u0648\u0644\u0648"
+    ],
     "name:ceb_x_preferred":[
         "Bopolu"
     ],
@@ -60,6 +63,9 @@
     ],
     "name:swe_x_preferred":[
         "Bopolu"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e42\u0e1a\u0e1e\u0e39\u0e25\u0e39"
     ],
     "name:ukr_x_preferred":[
         "\u0411\u043e\u043f\u043e\u043b\u0443"
@@ -106,7 +112,7 @@
         }
     ],
     "wof:id":890417993,
-    "wof:lastmodified":1566596276,
+    "wof:lastmodified":1690938593,
     "wof:name":"Bopolu",
     "wof:parent_id":1091693577,
     "wof:placetype":"locality",

--- a/data/890/422/439/890422439.geojson
+++ b/data/890/422/439/890422439.geojson
@@ -49,6 +49,9 @@
     "name:pol_x_preferred":[
         "Yekepa"
     ],
+    "name:por_x_preferred":[
+        "Yekepa"
+    ],
     "name:swe_x_preferred":[
         "New Yekepa"
     ],
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":890422439,
-    "wof:lastmodified":1566596276,
+    "wof:lastmodified":1690938592,
     "wof:name":"New Yekepa",
     "wof:parent_id":1091694197,
     "wof:placetype":"locality",

--- a/data/890/436/563/890436563.geojson
+++ b/data/890/436/563/890436563.geojson
@@ -19,8 +19,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":10.0,
+    "name:ara_x_preferred":[
+        "\u063a\u0627\u0646\u062a\u0627"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0413\u0430\u043d\u0442\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0413\u0430\u043d\u0442\u0430"
+    ],
+    "name:ceb_x_preferred":[
+        "Ganta"
     ],
     "name:deu_x_preferred":[
         "Ganta"
@@ -33,6 +42,9 @@
     ],
     "name:ita_x_preferred":[
         "Ganta"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ac\u30f3\u30bf"
     ],
     "name:kat_x_preferred":[
         "\u10d2\u10d0\u10dc\u10e2\u10d0"
@@ -91,7 +103,7 @@
         }
     ],
     "wof:id":890436563,
-    "wof:lastmodified":1566596276,
+    "wof:lastmodified":1690938593,
     "wof:name":"Ganta",
     "wof:parent_id":1091694245,
     "wof:placetype":"locality",

--- a/data/890/441/387/890441387.geojson
+++ b/data/890/441/387/890441387.geojson
@@ -22,6 +22,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0424\u0456\u0448\u0442\u0430\u045e\u043d"
     ],
+    "name:bel_x_variant":[
+        "\u0424\u0456\u0448\u0442\u0430\u045e\u043d"
+    ],
     "name:ceb_x_preferred":[
         "Fish Town"
     ],
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":890441387,
-    "wof:lastmodified":1566596276,
+    "wof:lastmodified":1690938592,
     "wof:name":"Fish Town",
     "wof:parent_id":1091693159,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.