### PR TITLE
lr concordances, placetype local, and more

### DIFF
--- a/data/109/169/234/5/1091692345.geojson
+++ b/data/109/169/234/5/1091692345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.156236,
-    "geom:area_square_m":1918710767.364764,
+    "geom:area_square_m":1918710767.364779,
     "geom:bbox":"-11.081498,6.382694,-10.554447,6.990082",
     "geom:latitude":6.695895,
     "geom:longitude":-10.827794,
@@ -89,9 +89,10 @@
         "hasc:id":"LR.BM.KL",
         "wd:id":"Q1775196"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879413,
-    "wof:geomhash":"b85f12a8cfdd566334d22ba0046d7c36",
+    "wof:geomhash":"95914e9c13b3c0a8053115530b66b470",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091692345,
-    "wof:lastmodified":1690938587,
+    "wof:lastmodified":1695886739,
     "wof:name":"Klay",
     "wof:parent_id":85673523,
     "wof:placetype":"county",

--- a/data/109/169/238/1/1091692381.geojson
+++ b/data/109/169/238/1/1091692381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019496,
-    "geom:area_square_m":239379102.821031,
+    "geom:area_square_m":239379102.821022,
     "geom:bbox":"-10.703494,6.687273,-10.468464,6.8752",
     "geom:latitude":6.795077,
     "geom:longitude":-10.600342,
@@ -81,9 +81,10 @@
         "hasc:id":"LR.BM.SM",
         "wd:id":"Q1775227"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879414,
-    "wof:geomhash":"5dfdad8ec808e14d1fd71ebbe1b4936b",
+    "wof:geomhash":"a80d7fa144b5c38d7ea9a8ffe71beb63",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091692381,
-    "wof:lastmodified":1566596247,
+    "wof:lastmodified":1695886740,
     "wof:name":"Mecca",
     "wof:parent_id":85673523,
     "wof:placetype":"county",

--- a/data/109/169/242/3/1091692423.geojson
+++ b/data/109/169/242/3/1091692423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087167,
-    "geom:area_square_m":1069710069.37243,
+    "geom:area_square_m":1069710069.372427,
     "geom:bbox":"-10.128563,6.847413,-9.637717,7.197363",
     "geom:latitude":7.037815,
     "geom:longitude":-9.888776,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.BG.SY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879416,
-    "wof:geomhash":"230c0aa7520a27e806f1d6c03e409299",
+    "wof:geomhash":"47f3c013e48cb088488ac144dfe5e2b0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692423,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886797,
     "wof:name":"Sanoyea",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/244/5/1091692445.geojson
+++ b/data/109/169/244/5/1091692445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077683,
-    "geom:area_square_m":954160316.35962,
+    "geom:area_square_m":954160316.359621,
     "geom:bbox":"-9.665584,6.402098,-9.131348,6.80561",
     "geom:latitude":6.623006,
     "geom:longitude":-9.399736,
@@ -89,9 +89,10 @@
         "hasc:id":"LR.BG.KO",
         "wd:id":"Q3031349"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879417,
-    "wof:geomhash":"df7eaa54347957100b156f048e0d7ec4",
+    "wof:geomhash":"fa18f5ea19232f52e88a96557c124ec7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091692445,
-    "wof:lastmodified":1690938587,
+    "wof:lastmodified":1695886739,
     "wof:name":"Kokoyah",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/248/3/1091692483.geojson
+++ b/data/109/169/248/3/1091692483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044861,
-    "geom:area_square_m":550757817.76501,
+    "geom:area_square_m":550757817.765014,
     "geom:bbox":"-10.475844,6.700981,-10.196928,6.992798",
     "geom:latitude":6.847484,
     "geom:longitude":-10.346195,
@@ -83,9 +83,10 @@
         "hasc:id":"LR.BG.FU",
         "wd:id":"Q3031247"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879419,
-    "wof:geomhash":"64a5b5a1570821cf6f2f83d8f353aa2c",
+    "wof:geomhash":"c7c1f9c8f3f9b313af73424f45cf6694",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1091692483,
-    "wof:lastmodified":1690938588,
+    "wof:lastmodified":1695886740,
     "wof:name":"Fuamah",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/252/5/1091692525.geojson
+++ b/data/109/169/252/5/1091692525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.151401,
-    "geom:area_square_m":1858785992.011268,
+    "geom:area_square_m":1858785992.011276,
     "geom:bbox":"-10.33781,6.557268,-9.803072,7.139751",
     "geom:latitude":6.835329,
     "geom:longitude":-10.073543,
@@ -83,9 +83,10 @@
         "hasc:id":"LR.BG.SL",
         "wd:id":"Q3031804"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879420,
-    "wof:geomhash":"864b0565f154d5dc57a86a9bb8f9afbc",
+    "wof:geomhash":"167590e60aa109510e40f49b29d9cb9f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1091692525,
-    "wof:lastmodified":1690938588,
+    "wof:lastmodified":1695886740,
     "wof:name":"Salala",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/255/5/1091692555.geojson
+++ b/data/109/169/255/5/1091692555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070262,
-    "geom:area_square_m":861777491.654768,
+    "geom:area_square_m":861777491.654773,
     "geom:bbox":"-9.657014,7.13163,-9.160678,7.430015",
     "geom:latitude":7.289356,
     "geom:longitude":-9.368167,
@@ -83,9 +83,10 @@
         "hasc:id":"LR.BG.ZO",
         "wd:id":"Q3032018"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879422,
-    "wof:geomhash":"83f0ace5bc250c43456e13d3b5cca2c2",
+    "wof:geomhash":"25e023d55564c36fe06794c448f7dec0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1091692555,
-    "wof:lastmodified":1690938588,
+    "wof:lastmodified":1695886740,
     "wof:name":"Zota",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/259/9/1091692599.geojson
+++ b/data/109/169/259/9/1091692599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076534,
-    "geom:area_square_m":939285712.322854,
+    "geom:area_square_m":939285712.322857,
     "geom:bbox":"-9.35486,6.760811,-9.092455,7.278014",
     "geom:latitude":7.007691,
     "geom:longitude":-9.216368,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.BG.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879423,
-    "wof:geomhash":"a0d595f458d175a64f69103d73891ea0",
+    "wof:geomhash":"2ec2bb02cab0d726092f5299271f96c3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692599,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886797,
     "wof:name":"Panta-Kpai",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/264/5/1091692645.geojson
+++ b/data/109/169/264/5/1091692645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.123399,
-    "geom:area_square_m":1514759656.454237,
+    "geom:area_square_m":1514759656.454236,
     "geom:bbox":"-9.810796,6.563734,-9.458183,7.269937",
     "geom:latitude":6.910879,
     "geom:longitude":-9.636743,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.BG.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879425,
-    "wof:geomhash":"01da4a731cd8d92873cde93efa316d7d",
+    "wof:geomhash":"c421eb0dd7fceb24992bdaa925955cb8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692645,
-    "wof:lastmodified":1627522347,
+    "wof:lastmodified":1695886798,
     "wof:name":"Suakoko",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/269/7/1091692697.geojson
+++ b/data/109/169/269/7/1091692697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112603,
-    "geom:area_square_m":1382147246.880629,
+    "geom:area_square_m":1382147246.880612,
     "geom:bbox":"-9.573023,6.644296,-9.259462,7.211943",
     "geom:latitude":6.939602,
     "geom:longitude":-9.42929,
@@ -75,9 +75,10 @@
         "hasc:id":"LR.BG.JO",
         "wd:id":"Q3031310"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879426,
-    "wof:geomhash":"f8bdae54dfc95c0e57d2a5846ed888e6",
+    "wof:geomhash":"d3b628586b92fb245d8b68dd5dfeccc2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1091692697,
-    "wof:lastmodified":1566596244,
+    "wof:lastmodified":1695886739,
     "wof:name":"Jorquelleh",
     "wof:parent_id":85673525,
     "wof:placetype":"county",

--- a/data/109/169/270/9/1091692709.geojson
+++ b/data/109/169/270/9/1091692709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031952,
-    "geom:area_square_m":392813076.351804,
+    "geom:area_square_m":392813076.351806,
     "geom:bbox":"-10.36689,6.021556,-10.157532,6.289333",
     "geom:latitude":6.164585,
     "geom:longitude":-10.265329,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GB.OW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879429,
-    "wof:geomhash":"1f8e71f3a19fa6edc5e50c18dfec01e0",
+    "wof:geomhash":"2a15f54b0c4fc6380dbc01d67fa4bbbb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692709,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886797,
     "wof:name":"Owensgrove",
     "wof:parent_id":85673531,
     "wof:placetype":"county",

--- a/data/109/169/273/5/1091692735.geojson
+++ b/data/109/169/273/5/1091692735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078305,
-    "geom:area_square_m":962457309.991933,
+    "geom:area_square_m":962457309.991925,
     "geom:bbox":"-10.306499,5.953398,-10.029816,6.541392",
     "geom:latitude":6.27528,
     "geom:longitude":-10.157667,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GB.ON"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879431,
-    "wof:geomhash":"e3750e8df404d2af7e3e079883598b3b",
+    "wof:geomhash":"9ff0d37fd5f9854efcedaf4a82106df7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692735,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"District #1",
     "wof:parent_id":85673531,
     "wof:placetype":"county",

--- a/data/109/169/276/7/1091692767.geojson
+++ b/data/109/169/276/7/1091692767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133316,
-    "geom:area_square_m":1638107751.292337,
+    "geom:area_square_m":1638107751.29235,
     "geom:bbox":"-10.137267,6.18426,-9.613419,6.648652",
     "geom:latitude":6.429938,
     "geom:longitude":-9.862829,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GB.TW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879433,
-    "wof:geomhash":"bdaffe0a1576ff6483869c2ed32f28cd",
+    "wof:geomhash":"98db159b80927f06dec567a33e2510da",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692767,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"District #2",
     "wof:parent_id":85673531,
     "wof:placetype":"county",

--- a/data/109/169/281/5/1091692815.geojson
+++ b/data/109/169/281/5/1091692815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.205501,
-    "geom:area_square_m":2525840301.645147,
+    "geom:area_square_m":2525840301.645188,
     "geom:bbox":"-10.065657,5.78904,-9.160975,6.674112",
     "geom:latitude":6.27119,
     "geom:longitude":-9.596781,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GB.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879434,
-    "wof:geomhash":"d9f4aea9d7da58f758bec010b84854dc",
+    "wof:geomhash":"41904cc0b9057bfa1b09677cc00cfb0c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692815,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"District # 3",
     "wof:parent_id":85673531,
     "wof:placetype":"county",

--- a/data/109/169/286/5/1091692865.geojson
+++ b/data/109/169/286/5/1091692865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108317,
-    "geom:area_square_m":1332248015.357372,
+    "geom:area_square_m":1332248015.357343,
     "geom:bbox":"-9.972088,5.576626,-9.450349,6.215586",
     "geom:latitude":5.90508,
     "geom:longitude":-9.729084,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GB.FO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879436,
-    "wof:geomhash":"0c871679449145ba26cf70553d1e6e69",
+    "wof:geomhash":"38adeb21583fcd64375a1a30e1c12386",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692865,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"District # 4",
     "wof:parent_id":85673531,
     "wof:placetype":"county",

--- a/data/109/169/288/9/1091692889.geojson
+++ b/data/109/169/288/9/1091692889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052048,
-    "geom:area_square_m":639937011.435065,
+    "geom:area_square_m":639937011.435064,
     "geom:bbox":"-10.126986,5.922689,-9.851161,6.265738",
     "geom:latitude":6.099127,
     "geom:longitude":-9.992983,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GB.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879437,
-    "wof:geomhash":"ef2ae7f3596a75d832f229ac41780299",
+    "wof:geomhash":"64927bb0854472754a59abb981f52222",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692889,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"St. John River",
     "wof:parent_id":85673531,
     "wof:placetype":"county",

--- a/data/109/169/294/9/1091692949.geojson
+++ b/data/109/169/294/9/1091692949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046971,
-    "geom:area_square_m":576531079.105727,
+    "geom:area_square_m":576531079.10571,
     "geom:bbox":"-11.492083,6.774013,-11.162838,7.085744",
     "geom:latitude":6.957148,
     "geom:longitude":-11.313812,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.CM.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879439,
-    "wof:geomhash":"b5a809ded73afa4e42bb06075679ec8e",
+    "wof:geomhash":"e1c8473d519c466fefc94f9ae81dbea3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692949,
-    "wof:lastmodified":1627522347,
+    "wof:lastmodified":1695886798,
     "wof:name":"Tewor",
     "wof:parent_id":85673535,
     "wof:placetype":"county",

--- a/data/109/169/298/3/1091692983.geojson
+++ b/data/109/169/298/3/1091692983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133016,
-    "geom:area_square_m":1631386259.807528,
+    "geom:area_square_m":1631386259.807539,
     "geom:bbox":"-11.363108,7.067875,-10.614004,7.529269",
     "geom:latitude":7.31383,
     "geom:longitude":-10.990225,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.CM.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879440,
-    "wof:geomhash":"86617c276cb9ff737640572c7b2185e2",
+    "wof:geomhash":"29b2e59c98ca9fa9f12bfe6b4d7d54bc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692983,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886797,
     "wof:name":"Porkpa",
     "wof:parent_id":85673535,
     "wof:placetype":"county",

--- a/data/109/169/299/9/1091692999.geojson
+++ b/data/109/169/299/9/1091692999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.151334,
-    "geom:area_square_m":1856704581.894438,
+    "geom:area_square_m":1856704581.894417,
     "geom:bbox":"-11.195827,6.808079,-10.502628,7.47943",
     "geom:latitude":7.154495,
     "geom:longitude":-10.871572,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.CM.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879442,
-    "wof:geomhash":"9fee38203d9822618cde3db7d5caeec3",
+    "wof:geomhash":"b173f78d1898b9ad3181a647eced11d2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091692999,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"Gola Konneh",
     "wof:parent_id":85673535,
     "wof:placetype":"county",

--- a/data/109/169/304/1/1091693041.geojson
+++ b/data/109/169/304/1/1091693041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066563,
-    "geom:area_square_m":817285265.602427,
+    "geom:area_square_m":817285265.602415,
     "geom:bbox":"-11.328226,6.577183,-10.967372,6.974527",
     "geom:latitude":6.792419,
     "geom:longitude":-11.126766,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.CM.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879443,
-    "wof:geomhash":"a641f40437bb86200532141323c6a77a",
+    "wof:geomhash":"4d7b5dca30d283c27e2849731c7eff81",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693041,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"Garwula",
     "wof:parent_id":85673535,
     "wof:placetype":"county",

--- a/data/109/169/309/3/1091693093.geojson
+++ b/data/109/169/309/3/1091693093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009512,
-    "geom:area_square_m":116819071.202971,
+    "geom:area_square_m":116819071.202964,
     "geom:bbox":"-11.380162,6.6263,-11.159054,6.767702",
     "geom:latitude":6.692638,
     "geom:longitude":-11.260657,
@@ -145,9 +145,10 @@
     "wof:concordances":{
         "hasc:id":"LR.CM.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879445,
-    "wof:geomhash":"f79514163aec4d0073a7c8404942b60d",
+    "wof:geomhash":"fa3ad42dd6b32009d41d966452a1c673",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1091693093,
-    "wof:lastmodified":1636500660,
+    "wof:lastmodified":1695886763,
     "wof:name":"Robertsport",
     "wof:parent_id":85673535,
     "wof:placetype":"county",

--- a/data/109/169/311/3/1091693113.geojson
+++ b/data/109/169/311/3/1091693113.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1091693113,
-    "wof:lastmodified":1694492845,
+    "wof:lastmodified":1695886294,
     "wof:name":"Gbarzon",
     "wof:parent_id":85673559,
     "wof:placetype":"county",

--- a/data/109/169/311/7/1091693117.geojson
+++ b/data/109/169/311/7/1091693117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175347,
-    "geom:area_square_m":2156229055.214317,
+    "geom:area_square_m":2156229055.21431,
     "geom:bbox":"-8.462158,5.7065,-7.818991,6.315147",
     "geom:latitude":6.022537,
     "geom:longitude":-8.168202,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GD.TC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879448,
-    "wof:geomhash":"be14bc3e985f2b120eb13aeaa4b26899",
+    "wof:geomhash":"166d424297e70cf18a3281df4c8afd68",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693117,
-    "wof:lastmodified":1627522347,
+    "wof:lastmodified":1695886798,
     "wof:name":"Tchien",
     "wof:parent_id":85673559,
     "wof:placetype":"county",

--- a/data/109/169/311/9/1091693119.geojson
+++ b/data/109/169/311/9/1091693119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.340576,
-    "geom:area_square_m":4190040263.125313,
+    "geom:area_square_m":4190040263.125296,
     "geom:bbox":"-8.532284,5.510594,-7.371478,6.175814",
     "geom:latitude":5.756471,
     "geom:longitude":-7.879013,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GD.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879449,
-    "wof:geomhash":"a771290c808d446e177f9ad02b56f5ad",
+    "wof:geomhash":"94eb7f762a9a9f22f47dbe023aeb89f0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693119,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"Konobo",
     "wof:parent_id":85673559,
     "wof:placetype":"county",

--- a/data/109/169/312/5/1091693125.geojson
+++ b/data/109/169/312/5/1091693125.geojson
@@ -64,6 +64,7 @@
     "wof:concordances":{
         "hasc:id":"LR.GK.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879451,
     "wof:geomhash":"cd71da861481b6b5af33b9205500c56b",
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693125,
-    "wof:lastmodified":1695886798,
+    "wof:lastmodified":1696023153,
     "wof:name":"Webbo",
     "wof:parent_id":85673503,
     "wof:placetype":"county",

--- a/data/109/169/312/5/1091693125.geojson
+++ b/data/109/169/312/5/1091693125.geojson
@@ -76,7 +76,7 @@
         }
     ],
     "wof:id":1091693125,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886798,
     "wof:name":"Webbo",
     "wof:parent_id":85673503,
     "wof:placetype":"county",

--- a/data/109/169/315/9/1091693159.geojson
+++ b/data/109/169/315/9/1091693159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.311951,
-    "geom:area_square_m":3840751433.178826,
+    "geom:area_square_m":3840751433.178803,
     "geom:bbox":"-8.445521,4.966006,-7.780117,5.604562",
     "geom:latitude":5.313127,
     "geom:longitude":-8.114335,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.RG.GB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879452,
-    "wof:geomhash":"759d82450478f507fd0fe438b90cc90f",
+    "wof:geomhash":"5eb9f3da60885e1f8efd30d11a2ae449",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693159,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"Gbeapo",
     "wof:parent_id":85673503,
     "wof:placetype":"county",

--- a/data/109/169/317/9/1091693179.geojson
+++ b/data/109/169/317/9/1091693179.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1091693179,
-    "wof:lastmodified":1694492882,
+    "wof:lastmodified":1695886395,
     "wof:name":"Sasstown",
     "wof:parent_id":85673513,
     "wof:placetype":"county",

--- a/data/109/169/322/9/1091693229.geojson
+++ b/data/109/169/322/9/1091693229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041806,
-    "geom:area_square_m":515007363.433055,
+    "geom:area_square_m":515007363.433051,
     "geom:bbox":"-8.265945,4.819453,-8.010055,5.074275",
     "geom:latitude":4.951859,
     "geom:longitude":-8.148253,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GK.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879455,
-    "wof:geomhash":"de3e21b2d01b82073d42e2de90cc075d",
+    "wof:geomhash":"780e02e73e59c4c622b92bc4aa4e25c8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693229,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"Buah",
     "wof:parent_id":85673513,
     "wof:placetype":"county",

--- a/data/109/169/327/1/1091693271.geojson
+++ b/data/109/169/327/1/1091693271.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1091693271,
-    "wof:lastmodified":1694492891,
+    "wof:lastmodified":1695886417,
     "wof:name":"Upper Kru Coast",
     "wof:parent_id":85673513,
     "wof:placetype":"county",

--- a/data/109/169/331/9/1091693319.geojson
+++ b/data/109/169/331/9/1091693319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05818,
-    "geom:area_square_m":717076190.984881,
+    "geom:area_square_m":717076190.984864,
     "geom:bbox":"-8.06551,4.442457,-7.794002,4.764068",
     "geom:latitude":4.617486,
     "geom:longitude":-7.918148,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GK.TR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879458,
-    "wof:geomhash":"4b397fcc888154195b1563022ca68a24",
+    "wof:geomhash":"7ce1711ad870008146391a5b99067f8c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693319,
-    "wof:lastmodified":1627522347,
+    "wof:lastmodified":1695886798,
     "wof:name":"Trehn",
     "wof:parent_id":85673513,
     "wof:placetype":"county",

--- a/data/109/169/335/7/1091693357.geojson
+++ b/data/109/169/335/7/1091693357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045301,
-    "geom:area_square_m":554686338.459266,
+    "geom:area_square_m":554686338.45926,
     "geom:bbox":"-10.606035,7.885086,-10.337916,8.146354",
     "geom:latitude":8.013057,
     "geom:longitude":-10.475441,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.LF.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879459,
-    "wof:geomhash":"3d4bf0adc2be8d218f8a701ed2424a25",
+    "wof:geomhash":"71fcf3401b32a10db912de1065f0925a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693357,
-    "wof:lastmodified":1627522347,
+    "wof:lastmodified":1695886798,
     "wof:name":"Vahun",
     "wof:parent_id":85673539,
     "wof:placetype":"county",

--- a/data/109/169/340/1/1091693401.geojson
+++ b/data/109/169/340/1/1091693401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.218432,
-    "geom:area_square_m":2674387259.853658,
+    "geom:area_square_m":2674387259.853654,
     "geom:bbox":"-10.412223,7.715939,-9.822264,8.46362",
     "geom:latitude":8.040148,
     "geom:longitude":-10.130458,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.LF.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879461,
-    "wof:geomhash":"91d6177e3755f3aa6b9449b5cbfdf12c",
+    "wof:geomhash":"aeebb6c34c994c6af300a4ec9f112925",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693401,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"Kolahun",
     "wof:parent_id":85673539,
     "wof:placetype":"county",

--- a/data/109/169/342/7/1091693427.geojson
+++ b/data/109/169/342/7/1091693427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190554,
-    "geom:area_square_m":2331845555.703925,
+    "geom:area_square_m":2331845555.703907,
     "geom:bbox":"-10.014811,7.912738,-9.477335,8.551791",
     "geom:latitude":8.250752,
     "geom:longitude":-9.803517,
@@ -139,9 +139,10 @@
     "wof:concordances":{
         "hasc:id":"LR.LF.VO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879462,
-    "wof:geomhash":"c05cc32479765bcb760c8b979ef4640e",
+    "wof:geomhash":"53953bf01e608c9a01a2f9d70bee9df9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1091693427,
-    "wof:lastmodified":1636500660,
+    "wof:lastmodified":1695886763,
     "wof:name":"Voinjama",
     "wof:parent_id":85673539,
     "wof:placetype":"county",

--- a/data/109/169/346/5/1091693465.geojson
+++ b/data/109/169/346/5/1091693465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.229525,
-    "geom:area_square_m":2811320569.283815,
+    "geom:area_square_m":2811320569.283781,
     "geom:bbox":"-9.928775,7.520094,-9.343918,8.291079",
     "geom:latitude":7.877871,
     "geom:longitude":-9.618889,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"LR.LF.ZO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879464,
-    "wof:geomhash":"940b430114d7fdbb140cef0edd82d032",
+    "wof:geomhash":"568e9871c49fa7f5951ab78d28427e4e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091693465,
-    "wof:lastmodified":1627522347,
+    "wof:lastmodified":1695886798,
     "wof:name":"Zorzor",
     "wof:parent_id":85673539,
     "wof:placetype":"county",

--- a/data/109/169/350/5/1091693505.geojson
+++ b/data/109/169/350/5/1091693505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08675,
-    "geom:area_square_m":1063592220.195223,
+    "geom:area_square_m":1063592236.352561,
     "geom:bbox":"-9.747463,7.169598,-9.343929,7.748664",
     "geom:latitude":7.46035,
     "geom:longitude":-9.542419,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.LF.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879465,
-    "wof:geomhash":"fed5425f28c50cc4cb615c996fec1d46",
+    "wof:geomhash":"af6d876d1c404f35421f7b1197750840",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693505,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"Salayea",
     "wof:parent_id":85673539,
     "wof:placetype":"county",

--- a/data/109/169/353/5/1091693535.geojson
+++ b/data/109/169/353/5/1091693535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.135789,
-    "geom:area_square_m":1665515309.497611,
+    "geom:area_square_m":1665515309.4976,
     "geom:bbox":"-10.228488,7.023133,-9.66147,7.540313",
     "geom:latitude":7.279532,
     "geom:longitude":-9.918879,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GP.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879467,
-    "wof:geomhash":"55b837a553f5e1deeebe3158dba42019",
+    "wof:geomhash":"c45b2ba843fe7c5b5ab9f520272715c6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693535,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886796,
     "wof:name":"Bokomu",
     "wof:parent_id":85673507,
     "wof:placetype":"county",

--- a/data/109/169/357/7/1091693577.geojson
+++ b/data/109/169/357/7/1091693577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.207285,
-    "geom:area_square_m":2543123125.264921,
+    "geom:area_square_m":2543123125.264932,
     "geom:bbox":"-10.762362,6.806099,-10.02994,7.583609",
     "geom:latitude":7.159691,
     "geom:longitude":-10.403799,
@@ -103,9 +103,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GP.BP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879468,
-    "wof:geomhash":"6b6d399d6e1c0272388c10a93dac985e",
+    "wof:geomhash":"b5bdd6fafe9aa96b6c34be5440f70256",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1091693577,
-    "wof:lastmodified":1566596246,
+    "wof:lastmodified":1695886740,
     "wof:name":"Bopolu",
     "wof:parent_id":85673507,
     "wof:placetype":"county",

--- a/data/109/169/362/1/1091693621.geojson
+++ b/data/109/169/362/1/1091693621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.163237,
-    "geom:area_square_m":2000761429.553288,
+    "geom:area_square_m":2000761429.553305,
     "geom:bbox":"-10.316609,7.364806,-9.667558,7.866842",
     "geom:latitude":7.592235,
     "geom:longitude":-10.005103,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GP.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879470,
-    "wof:geomhash":"f45f3f518797a6c985ae91533611beee",
+    "wof:geomhash":"34bacce40784ba0728f303d4b5685ad2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693621,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886796,
     "wof:name":"Belle Yella",
     "wof:parent_id":85673507,
     "wof:placetype":"county",

--- a/data/109/169/366/3/1091693663.geojson
+++ b/data/109/169/366/3/1091693663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046111,
-    "geom:area_square_m":564063339.948305,
+    "geom:area_square_m":564063339.9483,
     "geom:bbox":"-10.313857,8.214167,-10.047395,8.52642",
     "geom:latitude":8.395752,
     "geom:longitude":-10.194489,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"LR.LF.FO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879471,
-    "wof:geomhash":"8bdac4f0a1f7ca0ca04cabf0571043bc",
+    "wof:geomhash":"a5aac9f12e8bfba6f70f819e30a47ea1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1091693663,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"Foya",
     "wof:parent_id":85673539,
     "wof:placetype":"county",

--- a/data/109/169/368/3/1091693683.geojson
+++ b/data/109/169/368/3/1091693683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164082,
-    "geom:area_square_m":2010655868.373322,
+    "geom:area_square_m":2010655868.373317,
     "geom:bbox":"-10.866773,7.476457,-10.249121,7.945693",
     "geom:latitude":7.689328,
     "geom:longitude":-10.508444,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GP.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879473,
-    "wof:geomhash":"5211ff853054eb76f8072328ed4a5199",
+    "wof:geomhash":"606cf956b39701f0706e751069aae554",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693683,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"Kongba",
     "wof:parent_id":85673507,
     "wof:placetype":"county",

--- a/data/109/169/371/3/1091693713.geojson
+++ b/data/109/169/371/3/1091693713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106197,
-    "geom:area_square_m":1302579856.23156,
+    "geom:area_square_m":1302579856.231564,
     "geom:bbox":"-10.955681,6.964479,-10.282408,7.532683",
     "geom:latitude":7.271108,
     "geom:longitude":-10.574176,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.GP.GB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879474,
-    "wof:geomhash":"212ee5f63471de85eef9f4ad12cdf156",
+    "wof:geomhash":"6782fb9fe78c1e428c4fe2efbd62c897",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693713,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"Gbarma",
     "wof:parent_id":85673507,
     "wof:placetype":"county",

--- a/data/109/169/375/9/1091693759.geojson
+++ b/data/109/169/375/9/1091693759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053498,
-    "geom:area_square_m":657109203.264787,
+    "geom:area_square_m":657109203.264801,
     "geom:bbox":"-10.214864,6.474752,-9.715301,6.792044",
     "geom:latitude":6.614512,
     "geom:longitude":-9.958959,
@@ -75,9 +75,10 @@
         "hasc:id":"LR.MG.GI",
         "wd:id":"Q3031265"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879476,
-    "wof:geomhash":"87154f4b141bf543cb5a80e7ded9c304",
+    "wof:geomhash":"aacb48505a9fa89ede29185e09c436a1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1091693759,
-    "wof:lastmodified":1566596250,
+    "wof:lastmodified":1695886740,
     "wof:name":"Gibi",
     "wof:parent_id":85673545,
     "wof:placetype":"county",

--- a/data/109/169/379/1/1091693791.geojson
+++ b/data/109/169/379/1/1091693791.geojson
@@ -136,9 +136,10 @@
     "wof:concordances":{
         "hasc:id":"LR.MG.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879477,
-    "wof:geomhash":"3f23ab193824b936b4de1e56d106ed9b",
+    "wof:geomhash":"0b9e49e2eb37aac71a8515adb2a15ab4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1091693791,
-    "wof:lastmodified":1636500660,
+    "wof:lastmodified":1695886763,
     "wof:name":"Kakata",
     "wof:parent_id":85673545,
     "wof:placetype":"county",

--- a/data/109/169/383/9/1091693839.geojson
+++ b/data/109/169/383/9/1091693839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041684,
-    "geom:area_square_m":512228010.462431,
+    "geom:area_square_m":512228010.462434,
     "geom:bbox":"-10.502646,6.247901,-10.219759,6.521617",
     "geom:latitude":6.3855,
     "geom:longitude":-10.355748,
@@ -94,9 +94,10 @@
     "wof:concordances":{
         "hasc:id":"LR.MG.FI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879479,
-    "wof:geomhash":"033ff1ae4b4d99282824c9562ee24158",
+    "wof:geomhash":"f9d8811b0c24bd528547625a38e9a03d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1091693839,
-    "wof:lastmodified":1566596245,
+    "wof:lastmodified":1695886739,
     "wof:name":"Firestone",
     "wof:parent_id":85673545,
     "wof:placetype":"county",

--- a/data/109/169/388/7/1091693887.geojson
+++ b/data/109/169/388/7/1091693887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039822,
-    "geom:area_square_m":489479138.76382,
+    "geom:area_square_m":489479138.763817,
     "geom:bbox":"-10.649265,6.116179,-10.341496,6.364315",
     "geom:latitude":6.252081,
     "geom:longitude":-10.49747,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.MG.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879480,
-    "wof:geomhash":"6afe44488ab044c838aff2f354ed1cc4",
+    "wof:geomhash":"39a4825242551e5a9909172489d2308c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091693887,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"Mambah Kaba",
     "wof:parent_id":85673545,
     "wof:placetype":"county",

--- a/data/109/169/393/1/1091693931.geojson
+++ b/data/109/169/393/1/1091693931.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1091693931,
-    "wof:lastmodified":1694492828,
+    "wof:lastmodified":1695886255,
     "wof:name":"Barrobo",
     "wof:parent_id":85673517,
     "wof:placetype":"county",

--- a/data/109/169/397/5/1091693975.geojson
+++ b/data/109/169/397/5/1091693975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125425,
-    "geom:area_square_m":1545873571.633787,
+    "geom:area_square_m":1545873571.633768,
     "geom:bbox":"-7.854185,4.353057,-7.521366,4.887398",
     "geom:latitude":4.615028,
     "geom:longitude":-7.689088,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"LR.MY.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879484,
-    "wof:geomhash":"93438511f2e500bb82bb29cb5b8379d3",
+    "wof:geomhash":"b3bc0ece32ca671e71fd1069f2aa65f5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1091693975,
-    "wof:lastmodified":1566596242,
+    "wof:lastmodified":1695886739,
     "wof:name":"Pleebo",
     "wof:parent_id":85673517,
     "wof:placetype":"county",

--- a/data/109/169/401/3/1091694013.geojson
+++ b/data/109/169/401/3/1091694013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064794,
-    "geom:area_square_m":795838808.006761,
+    "geom:area_square_m":795838808.006776,
     "geom:bbox":"-10.608866,6.419533,-10.371169,6.83262",
     "geom:latitude":6.627929,
     "geom:longitude":-10.481175,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.MO.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879485,
-    "wof:geomhash":"89e748d3d835e5021d60e94baed8b0fa",
+    "wof:geomhash":"deeadd87a7de967857f1019d2631165a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694013,
-    "wof:lastmodified":1627522347,
+    "wof:lastmodified":1695886798,
     "wof:name":"Todee",
     "wof:parent_id":85673541,
     "wof:placetype":"county",

--- a/data/109/169/404/5/1091694045.geojson
+++ b/data/109/169/404/5/1091694045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025637,
-    "geom:area_square_m":315004787.43541,
+    "geom:area_square_m":315004787.435402,
     "geom:bbox":"-10.680755,6.349206,-10.412889,6.547464",
     "geom:latitude":6.437341,
     "geom:longitude":-10.560861,
@@ -83,9 +83,10 @@
         "hasc:id":"LR.MO.CA",
         "wd:id":"Q985413"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879487,
-    "wof:geomhash":"fdc108f74313a077b999a02e1d2883e0",
+    "wof:geomhash":"53ad5b59724131d91473304ce025c565",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1091694045,
-    "wof:lastmodified":1690938588,
+    "wof:lastmodified":1695886740,
     "wof:name":"Careysburg",
     "wof:parent_id":85673541,
     "wof:placetype":"county",

--- a/data/109/169/408/3/1091694083.geojson
+++ b/data/109/169/408/3/1091694083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030134,
-    "geom:area_square_m":370265633.22052,
+    "geom:area_square_m":370265633.220516,
     "geom:bbox":"-10.807666,6.306778,-10.593617,6.588513",
     "geom:latitude":6.435871,
     "geom:longitude":-10.707388,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.MO.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879488,
-    "wof:geomhash":"862a4bbfb4387a6b332ee6d57fbac2b5",
+    "wof:geomhash":"19d379162d71c7a1226cbec9cb83e038",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694083,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"St. Paul River",
     "wof:parent_id":85673541,
     "wof:placetype":"county",

--- a/data/109/169/412/1/1091694121.geojson
+++ b/data/109/169/412/1/1091694121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013612,
-    "geom:area_square_m":167304569.15383,
+    "geom:area_square_m":167304569.153829,
     "geom:bbox":"-10.813504,6.215816,-10.6151,6.364958",
     "geom:latitude":6.292497,
     "geom:longitude":-10.712455,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.MO.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879490,
-    "wof:geomhash":"8744ef2b9ce27632ab4948c4c25924bd",
+    "wof:geomhash":"c8828a1fc4ed936446272a10fd3f32a2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694121,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"Greater Monrovia",
     "wof:parent_id":85673541,
     "wof:placetype":"county",

--- a/data/109/169/416/7/1091694167.geojson
+++ b/data/109/169/416/7/1091694167.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1091694167,
-    "wof:lastmodified":1694492881,
+    "wof:lastmodified":1695886393,
     "wof:name":"Saclepea Mah",
     "wof:parent_id":85673551,
     "wof:placetype":"county",

--- a/data/109/169/419/7/1091694197.geojson
+++ b/data/109/169/419/7/1091694197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.143709,
-    "geom:area_square_m":1762321393.457474,
+    "geom:area_square_m":1762321393.457457,
     "geom:bbox":"-9.11399,7.111162,-8.430848,7.696163",
     "geom:latitude":7.365693,
     "geom:longitude":-8.712321,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.NI.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879493,
-    "wof:geomhash":"fa35ba56365b7a1628029154b83a6f39",
+    "wof:geomhash":"9097b3a708963337cb152c18b1085350",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694197,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"Sanniquelleh Mahn",
     "wof:parent_id":85673551,
     "wof:placetype":"county",

--- a/data/109/169/424/5/1091694245.geojson
+++ b/data/109/169/424/5/1091694245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12459,
-    "geom:area_square_m":1528418228.884121,
+    "geom:area_square_m":1528418228.884119,
     "geom:bbox":"-8.641825,6.932464,-8.27361,7.513483",
     "geom:latitude":7.203571,
     "geom:longitude":-8.457999,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.NI.GG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879494,
-    "wof:geomhash":"4d64335956cd2323e54f1e46779eaa82",
+    "wof:geomhash":"5d37d7f72c05b576f4550941c4d291c2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694245,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"Gbehlageh",
     "wof:parent_id":85673551,
     "wof:placetype":"county",

--- a/data/109/169/429/7/1091694297.geojson
+++ b/data/109/169/429/7/1091694297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098045,
-    "geom:area_square_m":1203471204.416208,
+    "geom:area_square_m":1203471204.416242,
     "geom:bbox":"-8.814673,6.654299,-8.307361,7.175412",
     "geom:latitude":6.936491,
     "geom:longitude":-8.54752,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.NI.ZG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879496,
-    "wof:geomhash":"9c06251acbe332f2a80ab4cb3c528ddb",
+    "wof:geomhash":"ff5b5faed2f259edf353082bc446cf0d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694297,
-    "wof:lastmodified":1627522347,
+    "wof:lastmodified":1695886798,
     "wof:name":"Zoegeh",
     "wof:parent_id":85673551,
     "wof:placetype":"county",

--- a/data/109/169/433/3/1091694333.geojson
+++ b/data/109/169/433/3/1091694333.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1091694333,
-    "wof:lastmodified":1694492888,
+    "wof:lastmodified":1695886409,
     "wof:name":"Tappita",
     "wof:parent_id":85673551,
     "wof:placetype":"county",

--- a/data/109/169/438/7/1091694387.geojson
+++ b/data/109/169/438/7/1091694387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094476,
-    "geom:area_square_m":1160502251.575271,
+    "geom:area_square_m":1160502251.575251,
     "geom:bbox":"-9.165263,6.338488,-8.886688,6.847942",
     "geom:latitude":6.586554,
     "geom:longitude":-9.056015,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.NI.YW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879501,
-    "wof:geomhash":"2af5b053c947518eb70d86bb40add509",
+    "wof:geomhash":"ed95f182407dfda6471de614d04b245e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694387,
-    "wof:lastmodified":1627522347,
+    "wof:lastmodified":1695886798,
     "wof:name":"Yarwein Mehnsohnnoh",
     "wof:parent_id":85673551,
     "wof:placetype":"county",

--- a/data/109/169/441/7/1091694417.geojson
+++ b/data/109/169/441/7/1091694417.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1091694417,
-    "wof:lastmodified":1694492867,
+    "wof:lastmodified":1695886352,
     "wof:name":"Morweh",
     "wof:parent_id":85673557,
     "wof:placetype":"county",

--- a/data/109/169/446/1/1091694461.geojson
+++ b/data/109/169/446/1/1091694461.geojson
@@ -77,7 +77,7 @@
         }
     ],
     "wof:id":1091694461,
-    "wof:lastmodified":1694492374,
+    "wof:lastmodified":1695886739,
     "wof:name":"Timbo",
     "wof:parent_id":85673557,
     "wof:placetype":"county",

--- a/data/109/169/447/9/1091694479.geojson
+++ b/data/109/169/447/9/1091694479.geojson
@@ -53,7 +53,7 @@
         }
     ],
     "wof:id":1091694479,
-    "wof:lastmodified":1694492374,
+    "wof:lastmodified":1695886739,
     "wof:name":"",
     "wof:parent_id":85673557,
     "wof:placetype":"county",

--- a/data/109/169/449/7/1091694497.geojson
+++ b/data/109/169/449/7/1091694497.geojson
@@ -53,7 +53,7 @@
         }
     ],
     "wof:id":1091694497,
-    "wof:lastmodified":1694492374,
+    "wof:lastmodified":1695886739,
     "wof:name":"",
     "wof:parent_id":85673557,
     "wof:placetype":"county",

--- a/data/109/169/454/7/1091694547.geojson
+++ b/data/109/169/454/7/1091694547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.172965,
-    "geom:area_square_m":2128630419.82349,
+    "geom:area_square_m":2128630419.823522,
     "geom:bbox":"-9.171838,5.199863,-8.738239,5.94585",
     "geom:latitude":5.571327,
     "geom:longitude":-8.939827,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.SI.JU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879506,
-    "wof:geomhash":"0d4629e13cb6c2628988b6785989f18f",
+    "wof:geomhash":"5e4f2dd768dded5fca4590880863d9f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694547,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"Juarzon",
     "wof:parent_id":85673519,
     "wof:placetype":"county",

--- a/data/109/169/457/9/1091694579.geojson
+++ b/data/109/169/457/9/1091694579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124097,
-    "geom:area_square_m":1527278040.805835,
+    "geom:area_square_m":1527278040.805833,
     "geom:bbox":"-9.002433,5.125723,-8.289962,5.810405",
     "geom:latitude":5.550717,
     "geom:longitude":-8.643105,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.SI.PT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879508,
-    "wof:geomhash":"ebef11d54dac1a2533e9d26fd091c062",
+    "wof:geomhash":"8b0cf3aece231c7eca3e84a0b73e0d07",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694579,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"Pyneston",
     "wof:parent_id":85673519,
     "wof:placetype":"county",

--- a/data/109/169/461/9/1091694619.geojson
+++ b/data/109/169/461/9/1091694619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.143334,
-    "geom:area_square_m":1764847109.514175,
+    "geom:area_square_m":1764847109.514203,
     "geom:bbox":"-8.916814,5.010621,-8.42521,5.544283",
     "geom:latitude":5.271814,
     "geom:longitude":-8.603267,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.SI.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879510,
-    "wof:geomhash":"1cf4c77d83614090ef871b40fb487235",
+    "wof:geomhash":"61e5c0ee666a0d3804e5f7cb2ebb1760",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694619,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"Jaedae Jaedepo",
     "wof:parent_id":85673519,
     "wof:placetype":"county",

--- a/data/109/169/466/1/1091694661.geojson
+++ b/data/109/169/466/1/1091694661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034597,
-    "geom:area_square_m":426194924.618507,
+    "geom:area_square_m":426194924.618508,
     "geom:bbox":"-8.869824,4.828416,-8.588615,5.08809",
     "geom:latitude":4.960944,
     "geom:longitude":-8.744295,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.SI.DR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879511,
-    "wof:geomhash":"c28d3f3017e70b462748493f01fded85",
+    "wof:geomhash":"3f6073c65a92679a49734d7b34d2dd8e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694661,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"Dugbe River",
     "wof:parent_id":85673519,
     "wof:placetype":"county",

--- a/data/109/169/470/1/1091694701.geojson
+++ b/data/109/169/470/1/1091694701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066338,
-    "geom:area_square_m":817033916.714214,
+    "geom:area_square_m":817033916.714219,
     "geom:bbox":"-9.034864,4.924856,-8.69469,5.314406",
     "geom:latitude":5.104284,
     "geom:longitude":-8.868885,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.SI.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879513,
-    "wof:geomhash":"ab19fc669a3aa53c7d593edb2f193c71",
+    "wof:geomhash":"ceb553d8e3c70d7400d6c55a2812959a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694701,
-    "wof:lastmodified":1627522346,
+    "wof:lastmodified":1695886798,
     "wof:name":"Kpayan",
     "wof:parent_id":85673519,
     "wof:placetype":"county",

--- a/data/109/169/474/5/1091694745.geojson
+++ b/data/109/169/474/5/1091694745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.174201,
-    "geom:area_square_m":2144386235.508872,
+    "geom:area_square_m":2144386235.508828,
     "geom:bbox":"-9.417652,4.980921,-8.992774,5.845073",
     "geom:latitude":5.420563,
     "geom:longitude":-9.183218,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"LR.SI.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LR",
     "wof:created":1473879515,
-    "wof:geomhash":"6823097fb815193ec056c6b0abaaf93c",
+    "wof:geomhash":"6cb8f787cb8be1bd743a2a52711c992b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1091694745,
-    "wof:lastmodified":1627522345,
+    "wof:lastmodified":1695886797,
     "wof:name":"Butaw",
     "wof:parent_id":85673519,
     "wof:placetype":"county",

--- a/data/856/322/49/85632249.geojson
+++ b/data/856/322/49/85632249.geojson
@@ -1102,6 +1102,7 @@
         "hasc:id":"LR",
         "icao:code":"A8",
         "ioc:id":"LBR",
+        "iso:code":"LR",
         "itu:id":"LBR",
         "loc:id":"n79060233",
         "m49:code":"430",
@@ -1116,6 +1117,7 @@
         "wk:page":"Liberia",
         "wmo:id":"LI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:country_alpha3":"LBR",
     "wof:geom_alt":[
@@ -1137,7 +1139,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639530,
+    "wof:lastmodified":1695881186,
     "wof:name":"Liberia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/735/03/85673503.geojson
+++ b/data/856/735/03/85673503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.562325,
-    "geom:area_square_m":6923774212.837649,
+    "geom:area_square_m":6923774212.837699,
     "geom:bbox":"-8.445521,4.819366,-7.365113,5.604562",
     "geom:latitude":5.275873,
     "geom:longitude":-7.905116,
@@ -142,14 +142,16 @@
         "gn:id":2593120,
         "gp:id":-2346100,
         "hasc:id":"LR.RG",
+        "iso:code":"LR-RG",
         "iso:id":"LR-RG",
         "unlc:id":"LR-RG"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2e979915f1b5712a99937555b8631836",
+    "wof:geomhash":"df90712d1c5dc337d232ffd68050d69b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -164,7 +166,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500651,
+    "wof:lastmodified":1695884873,
     "wof:name":"River Gee",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/07/85673507.geojson
+++ b/data/856/735/07/85673507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.776589,
-    "geom:area_square_m":9522635011.158169,
+    "geom:area_square_m":9522635013.777567,
     "geom:bbox":"-10.955681,6.806099,-9.66147,7.945693",
     "geom:latitude":7.398706,
     "geom:longitude":-10.280613,
@@ -141,13 +141,15 @@
         "gn:id":2593119,
         "gp:id":-2346101,
         "hasc:id":"LR.GP",
+        "iso:code":"LR-GP",
         "iso:id":"LR-GP"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aa553a694fa2a493a229138b9c0efac4",
+    "wof:geomhash":"0b1ea3389bfe435cc0a94f39179e9223",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -162,7 +164,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1642551792,
+    "wof:lastmodified":1695885133,
     "wof:name":"Gbapolu",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/13/85673513.geojson
+++ b/data/856/735/13/85673513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307891,
-    "geom:area_square_m":3793784726.017619,
+    "geom:area_square_m":3793784726.017598,
     "geom:bbox":"-8.723857,4.442457,-7.794002,5.1102",
     "geom:latitude":4.797681,
     "geom:longitude":-8.244573,
@@ -280,17 +280,19 @@
         "gn:id":2588490,
         "gp:id":2346110,
         "hasc:id":"LR.GK",
+        "iso:code":"LR-GK",
         "iso:id":"LR-GK",
         "qs_pg:id":242446,
         "unlc:id":"LR-GK",
         "wd:id":"Q574952",
         "wk:page":"Grand Kru County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"88cc441a48580945903a627cfe4011c7",
+    "wof:geomhash":"85fea4c00e0930f8a829c6e5a60dad90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -305,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938585,
+    "wof:lastmodified":1695884873,
     "wof:name":"Grand Kru",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/17/85673517.geojson
+++ b/data/856/735/17/85673517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190752,
-    "geom:area_square_m":2350699182.918677,
+    "geom:area_square_m":2350699182.918642,
     "geom:bbox":"-8.107082,4.353057,-7.521366,5.071449",
     "geom:latitude":4.713178,
     "geom:longitude":-7.781088,
@@ -282,17 +282,19 @@
         "gn:id":2275099,
         "gp:id":2346107,
         "hasc:id":"LR.MY",
+        "iso:code":"LR-MY",
         "iso:id":"LR-MY",
         "qs_pg:id":229378,
         "unlc:id":"LR-MY",
         "wd:id":"Q870138",
         "wk:page":"Maryland County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"562ea2c60957225b14994342509123e1",
+    "wof:geomhash":"24f3b02641dedaee1706bf0526cab5a2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938583,
+    "wof:lastmodified":1695884873,
     "wof:name":"Maryland",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/19/85673519.geojson
+++ b/data/856/735/19/85673519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.715532,
-    "geom:area_square_m":8808370646.985012,
+    "geom:area_square_m":8808370646.984991,
     "geom:bbox":"-9.417652,4.828416,-8.289962,5.94585",
     "geom:latitude":5.398237,
     "geom:longitude":-8.864171,
@@ -280,17 +280,19 @@
         "gn:id":2273898,
         "gp:id":2346104,
         "hasc:id":"LR.SI",
+        "iso:code":"LR-SI",
         "iso:id":"LR-SI",
         "qs_pg:id":59662,
         "unlc:id":"LR-SI",
         "wd:id":"Q1043644",
         "wk:page":"Sinoe County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b01861481911e1152686daa4dd1d8ab2",
+    "wof:geomhash":"0b72ffbee62e64a17307cad3b97f1bef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -305,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938584,
+    "wof:lastmodified":1695884873,
     "wof:name":"Sinoe",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/23/85673523.geojson
+++ b/data/856/735/23/85673523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175732,
-    "geom:area_square_m":2158089870.185796,
+    "geom:area_square_m":2158089870.185792,
     "geom:bbox":"-11.081498,6.382694,-10.468464,6.990082",
     "geom:latitude":6.706899,
     "geom:longitude":-10.80256,
@@ -295,17 +295,19 @@
         "gn:id":2278324,
         "gp:id":2346109,
         "hasc:id":"LR.BM",
+        "iso:code":"LR-BM",
         "iso:id":"LR-BM",
         "qs_pg:id":984086,
         "unlc:id":"LR-BM",
         "wd:id":"Q844127",
         "wk:page":"Bomi County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2c8e60dab9bb2a64f46c060c153b8d26",
+    "wof:geomhash":"05a7b81d782344c73c202698baacb446",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938585,
+    "wof:lastmodified":1695884873,
     "wof:name":"Bomi",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/25/85673525.geojson
+++ b/data/856/735/25/85673525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.743909,
-    "geom:area_square_m":9131389685.235905,
+    "geom:area_square_m":9131389685.235891,
     "geom:bbox":"-10.475844,6.402098,-9.092455,7.430015",
     "geom:latitude":6.926547,
     "geom:longitude":-9.673189,
@@ -287,17 +287,19 @@
         "gn:id":2278292,
         "gp:id":2346099,
         "hasc:id":"LR.BG",
+        "iso:code":"LR-BG",
         "iso:id":"LR-BG",
         "qs_pg:id":1046869,
         "unlc:id":"LR-BG",
         "wd:id":"Q877578",
         "wk:page":"Bong County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e01e9095a63f37102932d9306a042ce6",
+    "wof:geomhash":"55992578849450c37f1be055f7b93382",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938585,
+    "wof:lastmodified":1695884873,
     "wof:name":"Bong",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/31/85673531.geojson
+++ b/data/856/735/31/85673531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.60944,
-    "geom:area_square_m":7491403466.073651,
+    "geom:area_square_m":7491403466.073633,
     "geom:bbox":"-10.36689,5.576626,-9.160975,6.674112",
     "geom:latitude":6.221089,
     "geom:longitude":-9.819449,
@@ -281,17 +281,19 @@
         "gn:id":2276630,
         "gp:id":2346105,
         "hasc:id":"LR.GB",
+        "iso:code":"LR-GB",
         "iso:id":"LR-GB",
         "qs_pg:id":9201,
         "unlc:id":"LR-GB",
         "wd:id":"Q1047895",
         "wk:page":"Grand Bassa County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de4cd855dad4fae43ff068e48d2d23ee",
+    "wof:geomhash":"41ce497eebb46b8d4cbab8e8b4df0058",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500652,
+    "wof:lastmodified":1695884873,
     "wof:name":"Grand Bassa",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/35/85673535.geojson
+++ b/data/856/735/35/85673535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.407397,
-    "geom:area_square_m":4998726257.613092,
+    "geom:area_square_m":4998726257.613063,
     "geom:bbox":"-11.492083,6.577183,-10.502628,7.529269",
     "geom:latitude":7.113823,
     "geom:longitude":-11.012081,
@@ -284,17 +284,19 @@
         "gn:id":2276627,
         "gp:id":2346106,
         "hasc:id":"LR.CM",
+        "iso:code":"LR-CM",
         "iso:id":"LR-CM",
         "qs_pg:id":894916,
         "unlc:id":"LR-CM",
         "wd:id":"Q1047921",
         "wk:page":"Grand Cape Mount County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"555c3c75942dd914bd348de58ca452ef",
+    "wof:geomhash":"5ceb3f55dd3424d2e50103ca05a80049",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -309,7 +311,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500651,
+    "wof:lastmodified":1695884873,
     "wof:name":"Grand Cape Mount",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/39/85673539.geojson
+++ b/data/856/735/39/85673539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.816661,
-    "geom:area_square_m":9999757651.58853,
+    "geom:area_square_m":9999757683.813267,
     "geom:bbox":"-10.606035,7.169598,-9.343918,8.551791",
     "geom:latitude":8.00067,
     "geom:longitude":-9.870681,
@@ -282,16 +282,18 @@
         "gn:id":2275344,
         "gp:id":2346101,
         "hasc:id":"LR.LF",
+        "iso:code":"LR-LO",
         "iso:id":"LR-LO",
         "qs_pg:id":191376,
         "wd:id":"Q870130",
         "wk:page":"Lofa County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2f51a5ef2d1d5bd7a2a6ee32f61a340d",
+    "wof:geomhash":"7af76cd1ddeae8dffa6473588770f328",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938584,
+    "wof:lastmodified":1695884873,
     "wof:name":"Lofa",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/41/85673541.geojson
+++ b/data/856/735/41/85673541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134177,
-    "geom:area_square_m":1648413797.816552,
+    "geom:area_square_m":1648413797.816511,
     "geom:bbox":"-10.813504,6.215816,-10.371169,6.83262",
     "geom:latitude":6.514351,
     "geom:longitude":-10.570667,
@@ -291,17 +291,19 @@
         "gn:id":2274890,
         "gp:id":2346108,
         "hasc:id":"LR.MO",
+        "iso:code":"LR-MO",
         "iso:id":"LR-MO",
         "qs_pg:id":423791,
         "unlc:id":"LR-MO",
         "wd:id":"Q862608",
         "wk:page":"Montserrado County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2c3aed16b262df5cba8345363c886a71",
+    "wof:geomhash":"2d4db6b6771e9c83021feeed148c25ab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -316,7 +318,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938584,
+    "wof:lastmodified":1695884873,
     "wof:name":"Montserrado",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/45/85673545.geojson
+++ b/data/856/735/45/85673545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175186,
-    "geom:area_square_m":2152352965.526602,
+    "geom:area_square_m":2152352965.526628,
     "geom:bbox":"-10.649265,6.116179,-9.715301,6.792044",
     "geom:latitude":6.482086,
     "geom:longitude":-10.255634,
@@ -279,17 +279,19 @@
         "gn:id":2588491,
         "gp:id":2346111,
         "hasc:id":"LR.MG",
+        "iso:code":"LR-MG",
         "iso:id":"LR-MG",
         "qs_pg:id":229379,
         "unlc:id":"LR-MG",
         "wd:id":"Q1052737",
         "wk:page":"Margibi County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4c009e81f1d0f9c969f1ad60b805d0b2",
+    "wof:geomhash":"776324b52d0cb648f6f6a8e421242937",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -304,7 +306,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938583,
+    "wof:lastmodified":1695884873,
     "wof:name":"Margibi",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/51/85673551.geojson
+++ b/data/856/735/51/85673551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.935024,
-    "geom:area_square_m":11479512139.11512,
+    "geom:area_square_m":11479512139.114956,
     "geom:bbox":"-9.19553,5.823892,-8.27361,7.696163",
     "geom:latitude":6.825738,
     "geom:longitude":-8.76816,
@@ -279,17 +279,19 @@
         "gn:id":2274688,
         "gp:id":2346103,
         "hasc:id":"LR.NI",
+        "iso:code":"LR-NI",
         "iso:id":"LR-NI",
         "qs_pg:id":1153717,
         "unlc:id":"LR-NI",
         "wd:id":"Q868497",
         "wk:page":"Nimba County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f0b109f210e37060846acb4b2d520f31",
+    "wof:geomhash":"defa8ce86d3e39f0eae5d1f7562a9aa0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -304,7 +306,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938583,
+    "wof:lastmodified":1695884873,
     "wof:name":"Nimba",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/57/85673557.geojson
+++ b/data/856/735/57/85673557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.436109,
-    "geom:area_square_m":5364107807.048317,
+    "geom:area_square_m":5364107807.048388,
     "geom:bbox":"-9.741412,5.266829,-9.066276,6.379754",
     "geom:latitude":5.883787,
     "geom:longitude":-9.388625,
@@ -270,16 +270,18 @@
         "gn:id":2588492,
         "gp:id":2346112,
         "hasc:id":"LR.RI",
+        "iso:code":"LR-RI",
         "iso:id":"LR-RI",
         "qs_pg:id":191384,
         "wd:id":"Q955095",
         "wk:page":"Rivercess County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"efa38b90ead213d7e0b96c5f558e5ec8",
+    "wof:geomhash":"491052a8ae50e3a6bb0ca808ed735d7f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -294,7 +296,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636500651,
+    "wof:lastmodified":1695884873,
     "wof:name":"River Cess",
     "wof:parent_id":85632249,
     "wof:placetype":"region",

--- a/data/856/735/59/85673559.geojson
+++ b/data/856/735/59/85673559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.838139,
-    "geom:area_square_m":10307924686.960272,
+    "geom:area_square_m":10307924686.960165,
     "geom:bbox":"-8.951892,5.510594,-7.371478,6.505595",
     "geom:latitude":5.945311,
     "geom:longitude":-8.199421,
@@ -280,16 +280,18 @@
         "gn:id":2276622,
         "gp:id":2346100,
         "hasc:id":"LR.GD",
+        "iso:code":"LR-GG",
         "iso:id":"LR-GG",
         "qs_pg:id":998620,
         "wd:id":"Q950841",
         "wk:page":"Grand Gedeh County"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aab371a683803cfb37da42fa61f2c1df",
+    "wof:geomhash":"ef82e108a07715cdac2cb514bcdaa15b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -304,7 +306,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690938582,
+    "wof:lastmodified":1695884873,
     "wof:name":"Grand Gedeh",
     "wof:parent_id":85632249,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.